### PR TITLE
build & docs: fix uv/pyproject.toml build errors and improve README setup hints

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,12 +24,13 @@ HDMI is a framework that enables humanoid robots to acquire diverse whole-body i
 
 ```bash
 uv sync
+source .venv/bin/activate
 ```
 
 If you prefer conda, create a Python 3.12 environment and `pip install -r requirements.txt`.
 
 ## Sim2Sim
-The sim2sim setup runs a MuJoCo environment and a reinforcement-learning policy as two Python processes that communicate over ZMQ. After both processes are up, press `]` in the policy terminal to start, then press `9` in the MuJoCo viewer to disable the virtual gantry.
+The sim2sim setup runs a MuJoCo environment and a reinforcement-learning policy as two Python processes that communicate over ZMQ. After both processes are up, press `]` in the policy terminal to start, then press `9` in the MuJoCo viewer to disable the virtual gantry immediately.
 
 ### Example Scenarios
 **Move suitcase**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,4 +27,7 @@ Homepage = "https://hdmi-humanoid.github.io/"
 Repository = "https://github.com/EGalahad/sim2real"
 
 [tool.uv]
-package = "hdmi-sim2real"
+package = true
+
+[tool.setuptools]
+packages = ["utils"]


### PR DESCRIPTION
## Summary  
Fixes two `uv sync` failures and clarifies the README so new users can activate the venv and start Sim2Sim without stumbling.

## Changes  
1. **build**  
   - Correct `[tool.uv]` section 
   - Add `[tool.setuptools]` with explicit `packages` list to prevent auto-discovery conflict  

2. **docs**  
   - Add `source .venv/bin/activate` example in *Environment Setup*  
   - Emphasize “immediately” in *Sim2Sim* section  

## Verification  
- [x] `uv sync` completes successfully  
- [x] No functional code touched—only build config and documentation

## Summary by Sourcery

Adjust packaging configuration and virtual environment setup guidance to resolve uv build issues and clarify Sim2Sim startup instructions.

Build:
- Update uv configuration to use package auto-discovery and configure setuptools with an explicit packages list for the project.

Documentation:
- Document virtual environment activation in the setup instructions and clarify the timing of disabling the virtual gantry in the Sim2Sim section.