### PR TITLE
fix sonic & twist2 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,13 @@ prebuilt
 .cache
 external/
 .venv/
+
+# Local caches / temporary comparison artifacts
+.hf-cache-local/
+.tmp-groot-wbc/
+.tmp-policy-zip-compare-*/
+outputs/*.npz
+
 docs/node_modules/
 docs/.cache/
 docs/.docusaurus/

--- a/sim2real/rl_policy/base_policy.py
+++ b/sim2real/rl_policy/base_policy.py
@@ -18,6 +18,7 @@ from sim2real.rl_policy.inference import Timer, build_inference_module
 from sim2real.rl_policy.observations import Observation, ObsGroup
 from sim2real.rl_policy.utils.command_sender import ActionManager
 from sim2real.rl_policy.utils.state_processor import StateProcessor
+from sim2real.rl_policy.utils.upstream_real_io import UpstreamG1IO
 from sim2real.utils.common import PORTS
 from sim2real.utils.profiling import ScopedTimer
 from sim2real.utils.strings import resolve_matching_names_values
@@ -66,8 +67,26 @@ class BasePolicy:
         # initialize robot related processes
         self.joint_names_simulation = list(policy_config["joint_names_simulation"])
         self.body_names_simulation = list(policy_config["body_names_simulation"])
-        self.state_processor = StateProcessor(self.robot_cfg, policy_config)
-        self.action_manager = ActionManager(self.robot_cfg, policy_config)
+        self.real_io_backend = None
+        if args.real_io_backend == "upstream":
+            if args.robot != "g1":
+                raise NotImplementedError(
+                    "real_io_backend='upstream' is currently implemented only for robot='g1'."
+                )
+            self.real_io_backend = UpstreamG1IO(
+                interface=args.robot_interface,
+                joint_count=len(self.robot_cfg.joint_names),
+            )
+        self.state_processor = StateProcessor(
+            self.robot_cfg,
+            policy_config,
+            real_io_backend=self.real_io_backend,
+        )
+        self.action_manager = ActionManager(
+            self.robot_cfg,
+            policy_config,
+            real_io_backend=self.real_io_backend,
+        )
         self.rl_dt = 1.0 / float(args.rl_rate)
         self.inference_backend = args.inference_backend
 
@@ -490,6 +509,8 @@ class BasePolicy:
         finally:
             self._save_recording()
             self.controller.close()
+            if self.real_io_backend is not None:
+                self.real_io_backend.close()
 
     def step(self):
         with ScopedTimer("rl_policy.step") as step_timer:
@@ -609,6 +630,8 @@ class BasePolicyArgs:
     robot: str = "g1"
     rl_rate: float = 50.0
     inference_backend: Literal["onnx-gpu", "onnx-cpu", "tensorrt"] = "onnx-cpu"
+    real_io_backend: Literal["zmq", "upstream"] = "zmq"
+    robot_interface: str = "eth0"
     controller: Literal["keyboard", "joystick", "pico"] = "keyboard"
     pico_zmq_connect: str = f"tcp://127.0.0.1:{PORTS['pico_controller']}"
     record: bool = False

--- a/sim2real/rl_policy/inference/__init__.py
+++ b/sim2real/rl_policy/inference/__init__.py
@@ -1,10 +1,9 @@
 from typing import Literal
 
 from sim2real.rl_policy.inference.onnx_module import ONNXModule, Timer as Timer
-from sim2real.rl_policy.inference.tensorrt_module import TensorRTModule
 
 InferenceBackend = Literal["onnx-gpu", "onnx-cpu", "tensorrt"]
-__all__ = ["InferenceBackend", "ONNXModule", "TensorRTModule", "Timer", "build_inference_module"]
+__all__ = ["InferenceBackend", "ONNXModule", "Timer", "build_inference_module"]
 
 
 def build_inference_module(onnx_path: str, inference_backend: InferenceBackend):
@@ -12,5 +11,7 @@ def build_inference_module(onnx_path: str, inference_backend: InferenceBackend):
         provider = "gpu" if inference_backend == "onnx-gpu" else "cpu"
         return ONNXModule(onnx_path, providers=provider)
     if inference_backend == "tensorrt":
+        from sim2real.rl_policy.inference.tensorrt_module import TensorRTModule
+
         return TensorRTModule(onnx_path)
     raise ValueError(f"Unsupported inference backend: {inference_backend}")

--- a/sim2real/rl_policy/observations/sonic.py
+++ b/sim2real/rl_policy/observations/sonic.py
@@ -6,6 +6,7 @@ import numpy as np
 
 from sim2real.rl_policy.observations.base import Observation
 from sim2real.rl_policy.observations.common import _get_simulation_joint_selection
+from sim2real.rl_policy.utils.motion import MotionData
 from sim2real.utils.math import (
     matrix_from_quat,
     projected_yaw_quat,
@@ -22,12 +23,82 @@ class sonic_encoder_select(Observation):
 
 
 class sonic_encoder_index(Observation):
-    def __init__(self, width: int = 4, **kwargs):
+    def __init__(self, width: int = 4, mode_id: float = 0.0, **kwargs):
         super().__init__(**kwargs)
         self.width = int(width)
+        self.mode_id = float(mode_id)
 
     def compute(self) -> np.ndarray:
-        return np.zeros(self.width, dtype=np.float32)
+        out = np.zeros(self.width, dtype=np.float32)
+        if self.width:
+            out[0] = self.mode_id
+        return out
+
+
+class sonic_smpl_official_encoder_input(Observation):
+    """Full 1762D official encoder input with SMPL-mode fields populated.
+
+    Official deployment exports one encoder input containing all enabled encoder
+    observations. In SMPL mode only a subset is semantically required; the other
+    encoder fields are left as zero.
+    """
+
+    ENCODER_DIM = 1762
+    SMPL_MODE_ID = 2.0
+    SMPL_JOINTS_OFFSET = 922
+    SMPL_ANCHOR_OFFSET = 1642
+    WRIST_OFFSET = 1702
+    WRIST_JOINT_NAMES = (
+        "left_wrist_roll_joint",
+        "right_wrist_roll_joint",
+        "left_wrist_pitch_joint",
+        "right_wrist_pitch_joint",
+        "left_wrist_yaw_joint",
+        "right_wrist_yaw_joint",
+    )
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self._cached_joint_names: tuple[str, ...] | None = None
+        self._wrist_indices: np.ndarray | None = None
+
+    def _refresh_wrist_indices(self) -> np.ndarray:
+        joint_names = tuple(self.state_processor.motion_joint_names)
+        if self._cached_joint_names == joint_names and self._wrist_indices is not None:
+            return self._wrist_indices
+        missing = [name for name in self.WRIST_JOINT_NAMES if name not in joint_names]
+        if missing:
+            raise ValueError(f"SMPL motion joint_names missing wrist joints: {missing}")
+        self._wrist_indices = np.asarray(
+            [joint_names.index(name) for name in self.WRIST_JOINT_NAMES],
+            dtype=int,
+        )
+        self._cached_joint_names = joint_names
+        return self._wrist_indices
+
+    def compute(self) -> np.ndarray:
+        motion_data = self.state_processor.motion_data
+        out = np.zeros(self.ENCODER_DIM, dtype=np.float32)
+        out[0] = self.SMPL_MODE_ID
+        if motion_data is None:
+            return out
+
+        smpl_joints = np.asarray(motion_data.smpl_joints[0], dtype=np.float32)
+        out[self.SMPL_JOINTS_OFFSET : self.SMPL_JOINTS_OFFSET + 720] = smpl_joints.reshape(-1)
+
+        ref_root_quat_w = np.asarray(motion_data.body_quat_w[0], dtype=np.float32)
+        robot_root_quat_w = np.broadcast_to(
+            self.state_processor.root_quat_w.reshape(1, 4),
+            ref_root_quat_w.shape,
+        )
+        rel_quat = quat_mul(quat_conjugate(robot_root_quat_w), ref_root_quat_w)
+        anchor_ori = matrix_from_quat(rel_quat)[..., :, :2].reshape(-1)
+        out[self.SMPL_ANCHOR_OFFSET : self.SMPL_ANCHOR_OFFSET + 60] = anchor_ori
+
+        joint_pos = np.asarray(motion_data.joint_pos[0], dtype=np.float32)
+        wrists = joint_pos[:, self._refresh_wrist_indices()]
+        out[self.WRIST_OFFSET : self.WRIST_OFFSET + 60] = wrists.reshape(-1)
+        return out
 
 
 class _SonicMotionObservation(Observation):
@@ -71,13 +142,37 @@ class _SonicMotionObservation(Observation):
         self._cached_motion_layout = layout
 
     def _motion_slice(self, steps: np.ndarray):
-        if self.state_processor.motion_backend != "npz":
-            raise ValueError("SONIC motion observations currently require motion_backend=npz")
         self._refresh_motion_indices()
-        return self.state_processor.motion_dataset.get_slice(
-            self.state_processor.motion_ids,
-            self.state_processor.motion_t,
-            steps,
+        if self.state_processor.motion_backend == "npz":
+            return self.state_processor.motion_dataset.get_slice(
+                self.state_processor.motion_ids,
+                self.state_processor.motion_t,
+                steps,
+            )
+
+        motion_data: MotionData = self.state_processor.motion_data
+        available_steps = [
+            int(step) for step in self.state_processor.motion_future_steps.tolist()
+        ]
+        step_indices = []
+        for step in [int(step) for step in steps.tolist()]:
+            if step not in available_steps:
+                raise ValueError(
+                    f"SONIC requested future step {step}, "
+                    f"but motion source provides {available_steps}"
+                )
+            step_indices.append(available_steps.index(step))
+
+        return MotionData(
+            motion_id=np.take(motion_data.motion_id, step_indices, axis=1),
+            step=np.take(motion_data.step, step_indices, axis=1),
+            timestamps_ns=np.take(motion_data.timestamps_ns, step_indices, axis=1),
+            joint_pos=np.take(motion_data.joint_pos, step_indices, axis=1),
+            joint_vel=np.take(motion_data.joint_vel, step_indices, axis=1),
+            body_pos_w=np.take(motion_data.body_pos_w, step_indices, axis=1),
+            body_lin_vel_w=np.take(motion_data.body_lin_vel_w, step_indices, axis=1),
+            body_quat_w=np.take(motion_data.body_quat_w, step_indices, axis=1),
+            body_ang_vel_w=np.take(motion_data.body_ang_vel_w, step_indices, axis=1),
         )
 
     def _playback_steps(self) -> np.ndarray:

--- a/sim2real/rl_policy/observations/twist2.py
+++ b/sim2real/rl_policy/observations/twist2.py
@@ -152,7 +152,7 @@ class twist2_input(Observation):
                 self._robot_proprio_obs({"action": np.zeros(self.env.num_actions, dtype=np.float32)}),
             ]
         ).astype(np.float32)
-        self.history[:] = current
+        self.history.fill(0.0)
         self.input[0, :] = np.concatenate(
             [current, self.history.reshape(-1), self._motion_mimic_obs(future_step_index)]
         )

--- a/sim2real/rl_policy/tracking.py
+++ b/sim2real/rl_policy/tracking.py
@@ -26,7 +26,8 @@ def _apply_runtime_motion_config(
     motion_cfg["motion_backend"] = motion_backend
     if motion_backend == "npz" and motion_path is not None:
         motion_cfg["motion_path"] = motion_path
-    if motion_backend == "zmq":
+        motion_cfg["motion_dt_s"] = motion_dt_s
+    if motion_backend in {"zmq", "smpl_zmq"}:
         motion_cfg["motion_zmq_connect"] = motion_zmq_connect
         motion_cfg["motion_zmq_hwm"] = motion_zmq_hwm
         motion_cfg["motion_dt_s"] = motion_dt_s
@@ -48,9 +49,9 @@ class Tracking(BasePolicy):
             motion_dt_s=1 / self.args.rl_rate,
             motion_tolerance_s=self.args.motion_tolerance_s,
         )
-        if self.args.motion_backend == "zmq":
+        if self.args.motion_backend in {"zmq", "smpl_zmq"}:
             logger.info(
-                "Using runtime motion_backend=zmq "
+                f"Using runtime motion_backend={self.args.motion_backend} "
                 f"connect={self.args.motion_zmq_connect}"
             )
         return policy_config
@@ -77,7 +78,7 @@ class Tracking(BasePolicy):
 class TrackingArgs(BasePolicyArgs):
     """Robot."""
 
-    motion_backend: Literal["npz", "zmq"] = "npz"
+    motion_backend: Literal["npz", "zmq", "smpl_zmq"] = "npz"
     motion_path: Optional[str] = None
     motion_zmq_connect: str = "tcp://127.0.0.1:28701"
     motion_zmq_hwm: int = 1

--- a/sim2real/rl_policy/utils/command_sender.py
+++ b/sim2real/rl_policy/utils/command_sender.py
@@ -2,13 +2,20 @@ import numpy as np
 import zmq
 
 from sim2real.config.robots.base import RobotCfg
+from sim2real.rl_policy.utils.upstream_real_io import UpstreamG1IO
 from sim2real.utils.common import LowCmdMessage
 from sim2real.utils.strings import resolve_matching_names_values
 
 
 class ActionManager:
-    def __init__(self, robot_cfg: RobotCfg, policy_config):
+    def __init__(
+        self,
+        robot_cfg: RobotCfg,
+        policy_config,
+        real_io_backend: UpstreamG1IO | None = None,
+    ):
         self.robot_cfg = robot_cfg
+        self.real_io_backend = real_io_backend
 
         self.policy_config = policy_config
         joint_kp_dict = self.policy_config["joint_kp"]
@@ -49,15 +56,18 @@ class ActionManager:
         # ]
 
         # init low cmd publisher
-        self.zmq_context = zmq.Context.instance()
-        self.low_cmd_port = self.robot_cfg.low_cmd_port
-        bind_addr = self.robot_cfg.low_cmd_bind_addr
-        bind_endpoint = f"tcp://{bind_addr}:{self.low_cmd_port}"
+        if self.real_io_backend is None:
+            self.zmq_context = zmq.Context.instance()
+            self.low_cmd_port = self.robot_cfg.low_cmd_port
+            bind_addr = self.robot_cfg.low_cmd_bind_addr
+            bind_endpoint = f"tcp://{bind_addr}:{self.low_cmd_port}"
 
-        self.lowcmd_socket: zmq.Socket = self.zmq_context.socket(zmq.PUB)
-        self.lowcmd_socket.setsockopt(zmq.SNDHWM, 1)
-        self.lowcmd_socket.setsockopt(zmq.LINGER, 0)
-        self.lowcmd_socket.bind(bind_endpoint)
+            self.lowcmd_socket: zmq.Socket = self.zmq_context.socket(zmq.PUB)
+            self.lowcmd_socket.setsockopt(zmq.SNDHWM, 1)
+            self.lowcmd_socket.setsockopt(zmq.LINGER, 0)
+            self.lowcmd_socket.bind(bind_endpoint)
+        else:
+            self.lowcmd_socket = None
 
         self.InitLowCmd()
 
@@ -72,7 +82,17 @@ class ActionManager:
         self.cmd_q[:] = cmd_q
         self.cmd_dq[:] = cmd_dq
         self.cmd_tau[:] = cmd_tau
-        
+
+        if self.real_io_backend is not None:
+            self.real_io_backend.send_command(
+                cmd_q=self.cmd_q,
+                cmd_dq=self.cmd_dq,
+                cmd_tau=self.cmd_tau,
+                kp=self.joint_kp_unitree,
+                kd=self.joint_kd_unitree,
+            )
+            return
+
         message = LowCmdMessage(
             q_target=self.cmd_q,
             dq_target=self.cmd_dq,

--- a/sim2real/rl_policy/utils/motion_buffer.py
+++ b/sim2real/rl_policy/utils/motion_buffer.py
@@ -12,6 +12,28 @@ import zmq
 from loguru import logger
 from sim2real.config.robots.base import PICO_RECV_TIME_NS_KEY, PUBLISH_T_NS_KEY, RobotCfg
 from sim2real.rl_policy.utils.motion import MotionData, _normalize_quat_batch, _quat_slerp_batch
+from sim2real.utils.math import quat_conjugate, quat_mul
+
+
+class SmplMotionData:
+    def __init__(
+        self,
+        *,
+        timestamps_ns: np.ndarray,
+        step: np.ndarray,
+        smpl_pose: np.ndarray,
+        smpl_joints: np.ndarray,
+        body_quat_w: np.ndarray,
+        joint_pos: np.ndarray,
+        joint_vel: np.ndarray,
+    ) -> None:
+        self.timestamps_ns = timestamps_ns
+        self.step = step
+        self.smpl_pose = smpl_pose
+        self.smpl_joints = smpl_joints
+        self.body_quat_w = body_quat_w
+        self.joint_pos = joint_pos
+        self.joint_vel = joint_vel
 
 
 def _ensure_np(value: Any, ndim: int, dtype=np.float32) -> np.ndarray:
@@ -19,6 +41,39 @@ def _ensure_np(value: Any, ndim: int, dtype=np.float32) -> np.ndarray:
     if arr.ndim != ndim:
         raise ValueError(f"Expected ndim={ndim}, got shape={arr.shape}")
     return arr
+
+
+def _payload_scalar(value: Any, default: Any = None) -> Any:
+    if value is None:
+        return default
+    arr = np.asarray(value)
+    if arr.size == 0:
+        return default
+    return arr.reshape(-1)[0].item()
+
+
+def _quat_pair_ang_vel_w(q0_wxyz: np.ndarray, q1_wxyz: np.ndarray, dt_s: np.ndarray) -> np.ndarray:
+    q_delta = quat_mul(q1_wxyz, quat_conjugate(q0_wxyz))
+    q_delta = _normalize_quat_batch(q_delta, eps=1e-8)
+    q_delta = np.where(q_delta[..., :1] < 0.0, -q_delta, q_delta)
+
+    w = np.clip(q_delta[..., :1], -1.0, 1.0)
+    xyz = q_delta[..., 1:]
+    sin_half = np.linalg.norm(xyz, axis=-1, keepdims=True)
+    angle = 2.0 * np.arctan2(sin_half, w)
+    axis = np.divide(
+        xyz,
+        sin_half,
+        out=np.zeros_like(xyz),
+        where=sin_half > 1e-8,
+    )
+    rotvec = axis * angle
+    return np.divide(
+        rotvec,
+        dt_s[..., None],
+        out=np.zeros_like(rotvec),
+        where=dt_s[..., None] > 0.0,
+    ).astype(np.float32, copy=False)
 
 class RealtimeMotionBuffer:
     def __init__(
@@ -179,19 +234,28 @@ class RealtimeMotionBuffer:
         self,
         target_times_ns: np.ndarray,
         joint_pos_out: np.ndarray,
+        joint_vel_out: np.ndarray,
         body_pos_w_out: np.ndarray,
+        body_lin_vel_w_out: np.ndarray,
         body_quat_w_out: np.ndarray,
+        body_ang_vel_w_out: np.ndarray,
     ) -> None:
         if not self._timestamps_ns:
             joint_pos_out.fill(0.0)
+            joint_vel_out.fill(0.0)
             body_pos_w_out.fill(0.0)
+            body_lin_vel_w_out.fill(0.0)
             body_quat_w_out[:] = self._identity_quat
+            body_ang_vel_w_out.fill(0.0)
             return
 
         if len(self._timestamps_ns) == 1:
             joint_pos_out[:] = self._joint_pos_frames[0]
+            joint_vel_out.fill(0.0)
             body_pos_w_out[:] = self._body_pos_w_frames[0]
+            body_lin_vel_w_out.fill(0.0)
             body_quat_w_out[:] = self._body_quat_w_frames[0]
+            body_ang_vel_w_out.fill(0.0)
             return
 
         timestamps_ns = np.asarray(self._timestamps_ns, dtype=np.int64)
@@ -212,11 +276,25 @@ class RealtimeMotionBuffer:
         joint_pos_right = np.stack([self._joint_pos_frames[idx] for idx in right], axis=0)
         alpha_joint = alpha[:, None]
         joint_pos_out[:] = joint_pos_left + alpha_joint * (joint_pos_right - joint_pos_left)
+        dt_s = (t1 - t0).astype(np.float32, copy=False)[:, None] / 1e9
+        joint_vel_out[:] = np.divide(
+            joint_pos_right - joint_pos_left,
+            dt_s,
+            out=np.zeros_like(joint_vel_out),
+            where=dt_s > 0.0,
+        )
 
         body_pos_left = np.stack([self._body_pos_w_frames[idx] for idx in left], axis=0)
         body_pos_right = np.stack([self._body_pos_w_frames[idx] for idx in right], axis=0)
         alpha_body = alpha[:, None, None]
         body_pos_w_out[:] = body_pos_left + alpha_body * (body_pos_right - body_pos_left)
+        dt_body_s = (t1 - t0).astype(np.float32, copy=False)[:, None, None] / 1e9
+        body_lin_vel_w_out[:] = np.divide(
+            body_pos_right - body_pos_left,
+            dt_body_s,
+            out=np.zeros_like(body_lin_vel_w_out),
+            where=dt_body_s > 0.0,
+        )
 
         body_quat_left = np.stack([self._body_quat_w_frames[idx] for idx in left], axis=0)
         body_quat_right = np.stack([self._body_quat_w_frames[idx] for idx in right], axis=0)
@@ -227,6 +305,11 @@ class RealtimeMotionBuffer:
             normalize_inputs=False,
             eps=1e-8,
         ).astype(np.float32, copy=False)
+        body_ang_vel_w_out[:] = _quat_pair_ang_vel_w(
+            body_quat_left,
+            body_quat_right,
+            (t1 - t0).astype(np.float32, copy=False)[:, None] / 1e9,
+        )
 
     def cleanup(self, cutoff_ns: int) -> None:
         with self._lock:
@@ -257,8 +340,11 @@ class RealtimeMotionBuffer:
             self._fill_sample_frames_locked(
                 target_times_ns,
                 joint_pos[0],
+                joint_vel[0],
                 body_pos_w[0],
+                body_lin_vel_w[0],
                 body_quat_w[0],
+                body_ang_vel_w[0],
             )
 
         motion_data = MotionData(
@@ -273,3 +359,221 @@ class RealtimeMotionBuffer:
             body_ang_vel_w=body_ang_vel_w,
         )
         return motion_data
+
+
+class RealtimeSmplMotionBuffer:
+    def __init__(
+        self,
+        robot_cfg: RobotCfg,
+        future_steps: Iterable[int],
+        motion_zmq_connect: str | None = None,
+        motion_zmq_hwm: int = 1,
+        dt_s: float = 0.02,
+        tolerance_s: float = 0.04,
+    ) -> None:
+        self.robot_cfg = robot_cfg
+        self.joint_names: list[str] = list(self.robot_cfg.joint_names)
+        self.future_steps = np.asarray(list(future_steps), dtype=int)
+        if self.future_steps.ndim != 1:
+            raise ValueError(f"future_steps must be 1D, got {self.future_steps.shape}")
+        self.dt_s = float(dt_s)
+        if self.dt_s <= 0.0:
+            raise ValueError("dt_s must be positive")
+        self._dt_ns = int(self.dt_s * 1e9)
+        self._tolerance_ns = int(float(tolerance_s) * 1e9)
+        self._future_steps_ns = self.future_steps.astype(np.int64, copy=False) * self._dt_ns
+        self.min_future_step = int(np.min(self.future_steps)) if self.future_steps.size else 0
+        self.max_future_step = int(np.max(self.future_steps)) if self.future_steps.size else 0
+        self._delay_ns = self.max_future_step * self._dt_ns + self._tolerance_ns
+        self.delay_s = float(self._delay_ns / 1e9)
+        self._history_ns = self._delay_ns + abs(self.min_future_step) * self._dt_ns
+        self._identity_quat = np.array([1.0, 0.0, 0.0, 0.0], dtype=np.float32)
+
+        self._lock = threading.Lock()
+        self._timestamps_ns: list[int] = []
+        self._smpl_pose_frames: list[np.ndarray] = []
+        self._smpl_joints_frames: list[np.ndarray] = []
+        self._body_quat_w_frames: list[np.ndarray] = []
+        self._joint_pos_frames: list[np.ndarray] = []
+        self._step_template = self.future_steps.reshape(1, -1)
+
+        self._zmq_context = zmq.Context.instance()
+        self._motion_zmq_connect = motion_zmq_connect
+        self._motion_zmq_hwm = int(motion_zmq_hwm)
+        self._motion_stream_socket: zmq.Socket | None = None
+        self._motion_stream_thread: threading.Thread | None = None
+        self._motion_stream_stop = threading.Event()
+        if self._motion_zmq_connect:
+            self._start_motion_stream()
+
+    def _start_motion_stream(self) -> None:
+        if self._motion_stream_thread is not None:
+            return
+        sock = self._zmq_context.socket(zmq.SUB)
+        sock.setsockopt(zmq.LINGER, 0)
+        sock.setsockopt(zmq.RCVHWM, self._motion_zmq_hwm)
+        sock.setsockopt(zmq.SUBSCRIBE, b"")
+        sock.connect(self._motion_zmq_connect)
+        self._motion_stream_socket = sock
+
+        def _stream_loop() -> None:
+            while not self._motion_stream_stop.is_set():
+                try:
+                    raw = sock.recv_string(flags=zmq.NOBLOCK)
+                except zmq.Again:
+                    time.sleep(0.001)
+                    continue
+                except Exception as exc:
+                    logger.warning(f"SMPL motion subscriber error: {exc}")
+                    time.sleep(0.01)
+                    continue
+
+                try:
+                    self.__append_payload(raw, recv_time_ns=time.time_ns())
+                except Exception as exc:
+                    logger.warning(f"Failed to decode SMPL motion payload: {exc}")
+
+        self._motion_stream_thread = threading.Thread(target=_stream_loop, daemon=True)
+        self._motion_stream_thread.start()
+
+    def __append_payload(
+        self,
+        payload: dict[str, Any] | str | bytes,
+        recv_time_ns: int | None = None,
+    ) -> None:
+        if isinstance(payload, bytes):
+            payload = payload.decode("utf-8")
+        if isinstance(payload, str):
+            payload = json.loads(payload.strip())
+        if not isinstance(payload, dict):
+            raise TypeError(f"Unsupported payload type: {type(payload)}")
+
+        recv_time_ns = int(recv_time_ns or time.time_ns())
+        timestamp_ns = int(
+            _payload_scalar(payload.get(PICO_RECV_TIME_NS_KEY))
+            or _payload_scalar(payload.get("pico_recv_time_ns"))
+            or _payload_scalar(payload.get(PUBLISH_T_NS_KEY))
+            or recv_time_ns
+        )
+
+        smpl_pose = _ensure_np(payload["smpl_pose"], 3)
+        smpl_joints = _ensure_np(payload["smpl_joints"], 3)
+        body_quat_w = _ensure_np(payload["body_quat_w"], 2)
+        joint_pos = _ensure_np(payload["joint_pos"], 2)
+        if "joint_vel" in payload:
+            joint_vel = _ensure_np(payload["joint_vel"], 2)
+        else:
+            joint_vel = np.zeros_like(joint_pos, dtype=np.float32)
+
+        payload_joint_names = payload.get("joint_names")
+        if payload_joint_names is not None:
+            payload_joint_names = [str(name) for name in payload_joint_names]
+            if len(payload_joint_names) != joint_pos.shape[1]:
+                raise ValueError(
+                    "SMPL payload joint_names length "
+                    f"{len(payload_joint_names)} != joint_pos dim {joint_pos.shape[1]}"
+                )
+            if len(payload_joint_names) != len(self.joint_names):
+                raise ValueError(
+                    "SMPL payload joint_names length "
+                    f"{len(payload_joint_names)} != expected {len(self.joint_names)}"
+                )
+            self.joint_names[:] = payload_joint_names
+
+        num_frames = int(smpl_pose.shape[0])
+        if smpl_pose.shape != (num_frames, 21, 3):
+            raise ValueError(f"Expected smpl_pose [N,21,3], got {smpl_pose.shape}")
+        if smpl_joints.shape != (num_frames, 24, 3):
+            raise ValueError(f"Expected smpl_joints [N,24,3], got {smpl_joints.shape}")
+        if body_quat_w.shape != (num_frames, 4):
+            raise ValueError(f"Expected body_quat_w [N,4], got {body_quat_w.shape}")
+        if joint_pos.shape[0] != num_frames or joint_vel.shape != joint_pos.shape:
+            raise ValueError(
+                f"joint_pos/joint_vel shape mismatch: {joint_pos.shape} vs {joint_vel.shape}"
+            )
+        if joint_pos.shape[1] != len(self.joint_names):
+            raise ValueError(
+                f"Expected {len(self.joint_names)} joint positions, got {joint_pos.shape[1]}"
+            )
+
+        if "frame_index" in payload:
+            frame_index = np.asarray(payload["frame_index"], dtype=np.int64).reshape(-1)
+            if frame_index.shape[0] == num_frames:
+                timestamps = timestamp_ns + (frame_index - frame_index[-1]) * self._dt_ns
+            else:
+                timestamps = timestamp_ns + (np.arange(num_frames) - (num_frames - 1)) * self._dt_ns
+        else:
+            timestamps = timestamp_ns + (np.arange(num_frames) - (num_frames - 1)) * self._dt_ns
+
+        body_quat_w = _normalize_quat_batch(body_quat_w.astype(np.float32, copy=False))
+        with self._lock:
+            for i in range(num_frames):
+                ts = int(timestamps[i])
+                if self._timestamps_ns and ts <= self._timestamps_ns[-1]:
+                    # Current publisher sends single latest frames; ignore duplicate/out-of-order chunks.
+                    continue
+                self._timestamps_ns.append(ts)
+                self._smpl_pose_frames.append(smpl_pose[i].astype(np.float32, copy=True))
+                self._smpl_joints_frames.append(smpl_joints[i].astype(np.float32, copy=True))
+                self._body_quat_w_frames.append(body_quat_w[i].astype(np.float32, copy=True))
+                self._joint_pos_frames.append(joint_pos[i].astype(np.float32, copy=True))
+
+    def cleanup(self, cutoff_ns: int) -> None:
+        with self._lock:
+            while len(self._timestamps_ns) > 1 and self._timestamps_ns[1] < cutoff_ns:
+                self._timestamps_ns.pop(0)
+                self._smpl_pose_frames.pop(0)
+                self._smpl_joints_frames.pop(0)
+                self._body_quat_w_frames.pop(0)
+                self._joint_pos_frames.pop(0)
+
+    def _sample_array_locked(
+        self,
+        frames: list[np.ndarray],
+        target_times_ns: np.ndarray,
+    ) -> np.ndarray:
+        if not frames:
+            raise ValueError("No SMPL frames buffered")
+        if len(frames) == 1:
+            return np.broadcast_to(frames[0], (target_times_ns.shape[0], *frames[0].shape)).copy()
+        timestamps_ns = np.asarray(self._timestamps_ns, dtype=np.int64)
+        clamped = np.clip(target_times_ns, timestamps_ns[0], timestamps_ns[-1])
+        idx = np.searchsorted(timestamps_ns, clamped, side="left")
+        idx = np.clip(idx, 0, timestamps_ns.shape[0] - 1)
+        return np.stack([frames[int(i)] for i in idx], axis=0)
+
+    def get_obs(self) -> SmplMotionData:
+        current_time_ns = time.time_ns()
+        self.cleanup(current_time_ns - self._history_ns)
+        target_base_ns = current_time_ns - self._delay_ns
+        target_times_ns = target_base_ns + self._future_steps_ns
+        num_steps = self.future_steps.shape[0]
+
+        with self._lock:
+            if not self._timestamps_ns:
+                smpl_pose = np.zeros((num_steps, 21, 3), dtype=np.float32)
+                smpl_joints = np.zeros((num_steps, 24, 3), dtype=np.float32)
+                body_quat_w = np.broadcast_to(
+                    self._identity_quat, (num_steps, 4)
+                ).copy()
+                joint_pos = np.zeros((num_steps, len(self.joint_names)), dtype=np.float32)
+            else:
+                smpl_pose = self._sample_array_locked(self._smpl_pose_frames, target_times_ns)
+                smpl_joints = self._sample_array_locked(self._smpl_joints_frames, target_times_ns)
+                body_quat_w = self._sample_array_locked(self._body_quat_w_frames, target_times_ns)
+                joint_pos = self._sample_array_locked(self._joint_pos_frames, target_times_ns)
+
+        joint_vel = np.zeros_like(joint_pos, dtype=np.float32)
+        if joint_pos.shape[0] > 1:
+            joint_vel[:-1] = (joint_pos[1:] - joint_pos[:-1]) / self.dt_s
+            joint_vel[-1] = joint_vel[-2]
+
+        return SmplMotionData(
+            timestamps_ns=target_times_ns.reshape(1, -1),
+            step=self._step_template,
+            smpl_pose=smpl_pose.reshape(1, num_steps, 21, 3),
+            smpl_joints=smpl_joints.reshape(1, num_steps, 24, 3),
+            body_quat_w=body_quat_w.reshape(1, num_steps, 4),
+            joint_pos=joint_pos.reshape(1, num_steps, len(self.joint_names)),
+            joint_vel=joint_vel.reshape(1, num_steps, len(self.joint_names)),
+        )

--- a/sim2real/rl_policy/utils/state_processor.py
+++ b/sim2real/rl_policy/utils/state_processor.py
@@ -8,27 +8,35 @@ from loguru import logger
 from typing import Any, Dict, Optional
 from sim2real.config.robots.base import RobotCfg
 from sim2real.rl_policy.utils.motion import MotionDataset, MotionData, motion_dataset_first_motion
-from sim2real.rl_policy.utils.motion_buffer import RealtimeMotionBuffer
+from sim2real.rl_policy.utils.motion_buffer import RealtimeMotionBuffer, RealtimeSmplMotionBuffer
+from sim2real.rl_policy.utils.upstream_real_io import UpstreamG1IO
 from sim2real.utils.common import ZMQSubscriber, PORTS, LowStateMessage
 
 class StateProcessor:
     """Listens to the unitree sdk channels and converts observation into isaac compatible order.
     Assumes the message in the channel follows the joint order of robot_cfg.joint_names.
     """
-    def __init__(self, robot_cfg: RobotCfg, policy_config):
+    def __init__(
+        self,
+        robot_cfg: RobotCfg,
+        policy_config,
+        real_io_backend: UpstreamG1IO | None = None,
+    ):
         self.robot_cfg = robot_cfg
         self.mocap_ip = self.robot_cfg.mocap_ip
+        self.real_io_backend = real_io_backend
 
         self.low_state_port = self.robot_cfg.low_state_port
-        state_host = self.robot_cfg.low_state_host
-        state_endpoint = f"tcp://{state_host}:{self.low_state_port}"
+        if self.real_io_backend is None:
+            state_host = self.robot_cfg.low_state_host
+            state_endpoint = f"tcp://{state_host}:{self.low_state_port}"
 
-        self.zmq_context = zmq.Context.instance()
-        self.low_state_socket: zmq.Socket = self.zmq_context.socket(zmq.SUB)
-        self.low_state_socket.setsockopt(zmq.SUBSCRIBE, b"")
-        self.low_state_socket.setsockopt(zmq.CONFLATE, 1)
-        self.low_state_socket.setsockopt(zmq.RCVTIMEO, 10)
-        self.low_state_socket.connect(state_endpoint)
+            self.zmq_context = zmq.Context.instance()
+            self.low_state_socket: zmq.Socket = self.zmq_context.socket(zmq.SUB)
+            self.low_state_socket.setsockopt(zmq.SUBSCRIBE, b"")
+            self.low_state_socket.setsockopt(zmq.CONFLATE, 1)
+            self.low_state_socket.setsockopt(zmq.RCVTIMEO, 10)
+            self.low_state_socket.connect(state_endpoint)
         self.latest_low_state: LowStateMessage | None = None
 
         # Initialize joint mapping
@@ -122,6 +130,17 @@ class StateProcessor:
 
             self.motion_joint_names = list(self.motion_buffer.joint_names)
             self.motion_body_names = list(self.motion_buffer.body_names)
+        elif self.motion_backend == "smpl_zmq":
+            self.motion_buffer = RealtimeSmplMotionBuffer(
+                robot_cfg=self.robot_cfg,
+                future_steps=self.motion_future_steps,
+                motion_zmq_connect=self.motion_config.get("motion_zmq_connect", "tcp://127.0.0.1:28702"),
+                motion_zmq_hwm=int(self.motion_config.get("motion_zmq_hwm", 1)),
+                dt_s=float(self.motion_config.get("motion_dt_s", 0.02)),
+                tolerance_s=float(self.motion_config.get("motion_tolerance_s", 0.04)),
+            )
+            self.motion_joint_names = self.motion_buffer.joint_names
+            self.motion_body_names = []
         else:
             raise ValueError(f"Unsupported motion_backend: {motion_backend}")
 
@@ -133,6 +152,8 @@ class StateProcessor:
                 self.motion_future_steps,
             )
         elif self.motion_backend == "zmq":
+            self.motion_data = self.motion_buffer.get_obs()
+        elif self.motion_backend == "smpl_zmq":
             self.motion_data = self.motion_buffer.get_obs()
 
     def register_subscriber(self, object_name: str, port: Optional[int] = None):
@@ -170,6 +191,15 @@ class StateProcessor:
             return self.mocap_data.get(key, None)
 
     def _prepare_low_state(self):
+        if self.real_io_backend is not None:
+            self.latest_low_state = self.real_io_backend.read_low_state()
+            low_state = self.latest_low_state
+            self.root_quat_w[:] = low_state.quaternion
+            self.root_ang_vel_b[:] = low_state.gyroscope
+            self.joint_pos[:] = low_state.joint_positions
+            self.joint_vel[:] = low_state.joint_velocities
+            return True
+
         if hasattr(self, "low_state_socket"):
             self._receive_low_state()
             if not self.latest_low_state:

--- a/sim2real/rl_policy/utils/upstream_real_io.py
+++ b/sim2real/rl_policy/utils/upstream_real_io.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+
+import numpy as np
+from loguru import logger
+
+try:
+    import unitree_interface
+except ImportError:
+    unitree_interface = None
+
+try:
+    from unitree_sdk2py.comm.motion_switcher.motion_switcher_client import (
+        MotionSwitcherClient,
+    )
+except ImportError:
+    MotionSwitcherClient = None
+
+
+@dataclass
+class UpstreamLowStateSnapshot:
+    quaternion: np.ndarray
+    gyroscope: np.ndarray
+    joint_positions: np.ndarray
+    joint_velocities: np.ndarray
+    joint_torques: np.ndarray
+    tick: int
+
+
+class UpstreamG1IO:
+    """Direct Unitree I/O backend using the upstream unitree_interface binding."""
+
+    def __init__(self, *, interface: str, joint_count: int):
+        if unitree_interface is None:
+            raise ImportError(
+                "unitree_interface is required for real_io_backend='upstream' but is not installed."
+            )
+
+        self.interface = interface
+        self.joint_count = int(joint_count)
+        self.robot = unitree_interface.create_robot(
+            interface,
+            unitree_interface.RobotType.G1,
+            unitree_interface.MessageType.HG,
+        )
+        self.robot.set_control_mode(unitree_interface.ControlMode.PR)
+        self._release_motion_mode()
+        self.robot.read_low_state()
+        logger.info(
+            "Initialized upstream G1 I/O backend on {} with {} joints",
+            interface,
+            joint_count,
+        )
+
+    def _release_motion_mode(self) -> None:
+        if MotionSwitcherClient is None:
+            logger.info("MotionSwitcherClient unavailable; skipping motion mode release.")
+            return
+
+        try:
+            msc = MotionSwitcherClient()
+            msc.SetTimeout(5.0)
+            msc.Init()
+
+            status, result = msc.CheckMode()
+            logger.info("MotionSwitcher CheckMode: {}, {}", status, result)
+            while result is not None and result.get("name", ""):
+                logger.info("Releasing active motion mode: {}", result)
+                msc.ReleaseMode()
+                status, result = msc.CheckMode()
+                logger.info("MotionSwitcher CheckMode: {}, {}", status, result)
+                time.sleep(1.0)
+        except Exception as exc:
+            logger.warning("Motion mode release failed: {}", exc)
+
+    def read_low_state(self) -> UpstreamLowStateSnapshot:
+        low_state = self.robot.read_low_state()
+        count = self.joint_count
+        return UpstreamLowStateSnapshot(
+            quaternion=np.asarray(low_state.imu.quat, dtype=np.float32).copy(),
+            gyroscope=np.asarray(low_state.imu.omega, dtype=np.float32).copy(),
+            joint_positions=np.asarray(low_state.motor.q[:count], dtype=np.float32).copy(),
+            joint_velocities=np.asarray(low_state.motor.dq[:count], dtype=np.float32).copy(),
+            joint_torques=np.asarray(low_state.motor.tau_est[:count], dtype=np.float32).copy(),
+            tick=int(time.time_ns() // 1_000_000),
+        )
+
+    def send_command(
+        self,
+        *,
+        cmd_q: np.ndarray,
+        cmd_dq: np.ndarray,
+        cmd_tau: np.ndarray,
+        kp: np.ndarray,
+        kd: np.ndarray,
+    ) -> None:
+        cmd = self.robot.create_zero_command()
+        cmd.q_target = np.asarray(cmd_q, dtype=np.float32).copy()
+        cmd.dq_target = np.asarray(cmd_dq, dtype=np.float32).copy()
+        cmd.tau_ff = np.asarray(cmd_tau, dtype=np.float32).copy()
+        cmd.kp = np.asarray(kp, dtype=np.float32).copy().tolist()
+        cmd.kd = np.asarray(kd, dtype=np.float32).copy().tolist()
+        self.robot.write_low_command(cmd)
+
+    def close(self) -> None:
+        return

--- a/sim2real/sim_env/utils/mjcf.py
+++ b/sim2real/sim_env/utils/mjcf.py
@@ -87,7 +87,7 @@ def _temp_scene_with_floor(mjcf_path: Path) -> Path:
         if temp_path is not None:
             try:
                 temp_path.unlink()
-            except FileNotFoundError:
+            except (FileNotFoundError, PermissionError):
                 pass
         if staging_dir is not None:
             shutil.rmtree(staging_dir, ignore_errors=True)

--- a/sim2real/teleop/pico_retarget_pub.py
+++ b/sim2real/teleop/pico_retarget_pub.py
@@ -14,6 +14,7 @@ import json
 import time
 from typing import Literal, Optional
 
+import torch  # Import before MuJoCo/GMR native libs on aarch64 to avoid static TLS issues.
 import mujoco
 import numpy as np
 import tyro
@@ -37,6 +38,15 @@ from sim2real.config.robots.base import (
     XROBOT_BODY_POS_W_KEY,
     XROBOT_BODY_QUAT_W_KEY,
 )
+from sim2real.teleop.sonic_smpl_stream import (
+    DEFAULT_STANDING_SMPL_JOINTS,
+    DEFAULT_HUMAN_JOINTS_INFO_PATH,
+    ISAAC_G1_JOINT_NAMES,
+    build_smpl_frame,
+    build_smpl_frame_from_xrobot_raw,
+    json_safe_payload,
+    pack_pose_message,
+)
 from sim2real.utils.mjviser_viewer import MjviserMujocoViewer
 from sim2real.utils.common import PORTS, PicoControllerStateMessage
 from sim2real.utils.math import quat_conjugate, quat_mul, quat_rotate_inverse_numpy, quat_rotate_numpy, yaw_quat
@@ -54,6 +64,7 @@ MIN_HEIGHT_TIMER_NAME = "pico_retarget_pub.apply_min_link_height"
 BUILD_PAYLOAD_TIMER_NAME = "pico_retarget_pub.build_payload"
 SAMPLE_TIMER_NAME = "pico_retarget_pub.sample_and_retarget"
 SEND_TIMER_NAME = "pico_retarget_pub.send_payload"
+SMPL_SEND_TIMER_NAME = "pico_retarget_pub.send_smpl_payload"
 
 
 @dataclass(frozen=True)
@@ -150,7 +161,7 @@ def _xrobot_payload_dict(xrobot_frame: Optional[XRobotBodyFrame]) -> dict[str, o
 
 def _body_pose_dict_from_streamer(
     streamer: XRobotStreamer,
-) -> tuple[dict[str, list[np.ndarray]], int, int]:
+) -> tuple[dict[str, list[np.ndarray]], np.ndarray, int, int]:
     with ScopedTimer(BODY_POSE_TIMER_NAME):
         body_poses, _body_velocities, _body_accelerations, _imu_timestamps, body_timestamp = (
             streamer.get_raw_body_data()
@@ -158,17 +169,18 @@ def _body_pose_dict_from_streamer(
         pico_recv_time_ns = int(time.time_ns())
         if body_poses is None:
             raise RuntimeError("No XR body data available")
+        raw_body_poses = np.asarray(body_poses, dtype=np.float32).copy()
 
         body_pose_dict: dict[str, list[np.ndarray]] = {}
         for i, body_name in enumerate(streamer.body_joint_names):
-            pose = np.asarray(body_poses[i], dtype=np.float32).reshape(-1)
+            pose = raw_body_poses[i].reshape(-1)
             pos = pose[:3].astype(np.float32, copy=False)
             quat = np.asarray([pose[6], pose[3], pose[4], pose[5]], dtype=np.float32)
             body_pose_dict[body_name] = [pos, quat]
 
         # Keep the same coordinate transform that the streamer uses for its live path.
         body_pose_dict = streamer.coordinate_transform_unity_data(body_pose_dict).copy()
-        return body_pose_dict, int(body_timestamp), pico_recv_time_ns
+        return body_pose_dict, raw_body_poses, int(body_timestamp), pico_recv_time_ns
 
 
 def _controller_button_pressed(controller_data: object, controller_name: str, key_name: str) -> bool:
@@ -253,6 +265,19 @@ class LiveRetargetPublisher:
         self._controller_sock.setsockopt(zmq.SNDHWM, int(args.controller_hwm))
         self._controller_sock.setsockopt(zmq.CONFLATE, 1)
         self._controller_sock.bind(args.controller_bind)
+
+        self._smpl_frame_index = 0
+        self._last_smpl_frame: dict[str, np.ndarray] | None = None
+        self._smpl_heading_offset = np.asarray([1.0, 0.0, 0.0, 0.0], dtype=np.float32)
+        self._needs_smpl_heading_init = True
+        self._smpl_sock = None
+        if bool(args.publish_smpl):
+            self._smpl_sock = zmq.Context.instance().socket(zmq.PUB)
+            self._smpl_sock.setsockopt(zmq.LINGER, 0)
+            self._smpl_sock.setsockopt(zmq.SNDHWM, int(args.smpl_hwm))
+            if bool(args.smpl_conflate):
+                self._smpl_sock.setsockopt(zmq.CONFLATE, 1)
+            self._smpl_sock.bind(args.smpl_bind)
 
     def _resolve_joint_qpos_indices(self) -> list[int]:
         model = self.retarget.configuration.model
@@ -431,6 +456,149 @@ class LiveRetargetPublisher:
         except zmq.Again:
             pass
 
+    def _smpl_g1_joint_names(self) -> tuple[str, ...]:
+        if self.args.smpl_joint_order == "isaac":
+            return ISAAC_G1_JOINT_NAMES
+        return tuple(self.robot_cfg.joint_names)
+
+    def _default_smpl_joint_pos(self) -> np.ndarray:
+        qpos = np.asarray(self.robot_cfg.default_qpos, dtype=np.float32).reshape(-1)
+        robot_joint_pos = qpos[7 : 7 + len(self.robot_cfg.joint_names)]
+        robot_joint_by_name = {
+            name: robot_joint_pos[idx]
+            for idx, name in enumerate(self.robot_cfg.joint_names)
+        }
+        return np.asarray(
+            [robot_joint_by_name.get(name, 0.0) for name in self._smpl_g1_joint_names()],
+            dtype=np.float32,
+        )
+
+    def _current_smpl_heading_quat(self) -> np.ndarray:
+        if self._last_smpl_frame is None:
+            return np.asarray([1.0, 0.0, 0.0, 0.0], dtype=np.float32)
+        body_quat_w = np.asarray(self._last_smpl_frame["body_quat_w"], dtype=np.float32).reshape(1, 4)
+        return yaw_quat(body_quat_w).reshape(4).astype(np.float32, copy=False)
+
+    def _neutral_smpl_frame(self) -> dict[str, np.ndarray]:
+        return {
+            "smpl_pose": np.zeros((21, 3), dtype=np.float32),
+            "smpl_joints": DEFAULT_STANDING_SMPL_JOINTS.copy(),
+            "body_quat_w": self._current_smpl_heading_quat(),
+            "joint_pos": self._default_smpl_joint_pos(),
+        }
+
+    def _publish_smpl_frame_data(
+        self,
+        smpl_frame: dict[str, np.ndarray],
+        *,
+        source_smplx_t_ns: int,
+        pico_recv_time_ns: int,
+    ) -> None:
+        if self._smpl_sock is None:
+            return
+
+        fields = {
+            "smpl_pose": smpl_frame["smpl_pose"][None, ...].astype(np.float32, copy=False),
+            "smpl_joints": smpl_frame["smpl_joints"][None, ...].astype(np.float32, copy=False),
+            "body_quat_w": smpl_frame["body_quat_w"][None, ...].astype(np.float32, copy=False),
+            "joint_pos": smpl_frame["joint_pos"][None, ...].astype(np.float32, copy=False),
+            "joint_vel": np.zeros((1, len(self._smpl_g1_joint_names())), dtype=np.float32),
+            "frame_index": np.asarray([self._smpl_frame_index], dtype=np.int64),
+            "source_smplx_t_ns": np.asarray([int(source_smplx_t_ns)], dtype=np.int64),
+            "pico_recv_time_ns": np.asarray([int(pico_recv_time_ns)], dtype=np.int64),
+            "timestamp_monotonic": np.asarray([time.monotonic()], dtype=np.float64),
+            "timestamp_realtime": np.asarray([time.time()], dtype=np.float64),
+        }
+        self._smpl_frame_index += 1
+
+        with ScopedTimer(SMPL_SEND_TIMER_NAME):
+            try:
+                if self.args.smpl_wire_format == "packed":
+                    message = pack_pose_message(
+                        fields,
+                        topic=str(self.args.smpl_topic),
+                        version=int(self.args.smpl_protocol_version),
+                    )
+                    self._smpl_sock.send(message, flags=zmq.NOBLOCK)
+                else:
+                    payload = {
+                        "topic": str(self.args.smpl_topic),
+                        "version": int(self.args.smpl_protocol_version),
+                        "joint_names": list(self._smpl_g1_joint_names()),
+                        **json_safe_payload(fields),
+                    }
+                    self._smpl_sock.send_json(payload, flags=zmq.NOBLOCK)
+            except zmq.Again:
+                pass
+
+    def _publish_paused_smpl_frame(self) -> None:
+        smpl_frame = self._neutral_smpl_frame()
+        self._last_smpl_frame = {
+            key: np.asarray(value, dtype=np.float32).copy()
+            for key, value in smpl_frame.items()
+        }
+        self._publish_smpl_frame_data(
+            smpl_frame,
+            source_smplx_t_ns=int(self._latest_controller_t_ns),
+            pico_recv_time_ns=time.time_ns(),
+        )
+
+    def _publish_smpl_frame(
+        self,
+        body_pose_dict: dict[str, list[np.ndarray]],
+        *,
+        raw_body_poses: np.ndarray | None = None,
+        source_smplx_t_ns: int,
+        pico_recv_time_ns: int,
+    ) -> None:
+        if self._smpl_sock is None:
+            return
+
+        if raw_body_poses is None:
+            smpl_frame = build_smpl_frame(
+                body_pose_dict,
+                self.streamer.body_joint_names,
+                g1_joint_names=self._smpl_g1_joint_names(),
+                waist_yaw_offset_deg=float(self.args.smpl_waist_yaw_offset_deg),
+                wrist_mapping_mode=str(self.args.smpl_wrist_mapping),
+            )
+        else:
+            smpl_frame = build_smpl_frame_from_xrobot_raw(
+                raw_body_poses,
+                body_pose_dict,
+                self.streamer.body_joint_names,
+                g1_joint_names=self._smpl_g1_joint_names(),
+                waist_yaw_offset_deg=float(self.args.smpl_waist_yaw_offset_deg),
+                wrist_mapping_mode=str(self.args.smpl_wrist_mapping),
+                human_joints_info_path=str(self.args.smpl_human_joints_info_path),
+            )
+        body_quat_w = np.asarray(smpl_frame["body_quat_w"], dtype=np.float32).reshape(1, 4)
+        current_heading = yaw_quat(body_quat_w).reshape(4)
+        if self._needs_smpl_heading_init:
+            target_heading = self._current_smpl_heading_quat()
+            self._smpl_heading_offset = quat_mul(
+                target_heading.reshape(1, 4),
+                quat_conjugate(current_heading.reshape(1, 4)),
+            ).reshape(4).astype(np.float32, copy=False)
+            self._needs_smpl_heading_init = False
+        smpl_frame = {
+            key: np.asarray(value, dtype=np.float32).copy()
+            for key, value in smpl_frame.items()
+        }
+        smpl_frame["body_quat_w"] = quat_mul(
+            self._smpl_heading_offset.reshape(1, 4),
+            body_quat_w,
+        ).reshape(4).astype(np.float32, copy=False)
+        self._last_smpl_frame = {
+            key: np.asarray(value, dtype=np.float32).copy()
+            for key, value in smpl_frame.items()
+        }
+        self._publish_smpl_frame_data(
+            smpl_frame,
+            source_smplx_t_ns=source_smplx_t_ns,
+            pico_recv_time_ns=pico_recv_time_ns,
+        )
+
     def _build_payload(
         self,
         *,
@@ -483,6 +651,7 @@ class LiveRetargetPublisher:
             MIN_HEIGHT_TIMER_NAME,
             BUILD_PAYLOAD_TIMER_NAME,
             SEND_TIMER_NAME,
+            SMPL_SEND_TIMER_NAME,
             PAUSE_CAPTURE_TIMER_NAME,
             SAMPLE_TIMER_NAME,
         ):
@@ -538,11 +707,14 @@ class LiveRetargetPublisher:
                     self._capture_paused_qpos()
                 else:
                     self._needs_live_pelvis_init = True
+                    self._needs_smpl_heading_init = True
                 print(f"[Info] paused toggled to {self.paused} via PICO X button")
             self._x_button_was_pressed = x_pressed
 
             self._maybe_print_mode_hint()
             if self.paused:
+                if bool(self.args.publish_smpl):
+                    self._publish_paused_smpl_frame()
                 return self._build_payload(
                     source_smplx_t_ns=self._latest_controller_t_ns,
                     pico_recv_time_ns=time.time_ns(),
@@ -554,7 +726,7 @@ class LiveRetargetPublisher:
                 )
 
             try:
-                smplx_data, source_smplx_t_ns, pico_recv_time_ns = _body_pose_dict_from_streamer(self.streamer)
+                smplx_data, raw_body_poses, source_smplx_t_ns, pico_recv_time_ns = _body_pose_dict_from_streamer(self.streamer)
                 if source_smplx_t_ns > 0:
                     delay_ms = (pico_recv_time_ns - int(source_smplx_t_ns)) / 1e6
                     print(
@@ -585,6 +757,14 @@ class LiveRetargetPublisher:
                 smplx_data = self._apply_min_link_height_offset(
                     smplx_data,
                     raw_min_body_z=raw_min_body_z,
+                )
+
+            if bool(self.args.publish_smpl):
+                self._publish_smpl_frame(
+                    smplx_data,
+                    raw_body_poses=raw_body_poses,
+                    source_smplx_t_ns=int(source_smplx_t_ns),
+                    pico_recv_time_ns=int(pico_recv_time_ns),
                 )
 
             with ScopedTimer(RETARGET_TIMER_NAME):
@@ -631,6 +811,8 @@ class LiveRetargetPublisher:
 
     def close(self) -> None:
         self._controller_sock.close(0)
+        if self._smpl_sock is not None:
+            self._smpl_sock.close(0)
 
 
 class LiveRetargetMjviser:
@@ -739,6 +921,15 @@ def run_publish(args: "PublisherArgs") -> None:
         f"controller_bind={args.controller_bind} "
         f"mjcf={worker.robot_cfg.mjcf_path} resolved={worker.mjcf_path}"
     )
+    if args.publish_smpl:
+        print(
+            f"[publish] smpl_bind={args.smpl_bind} "
+            f"smpl_wire_format={args.smpl_wire_format} "
+            f"smpl_joint_order={args.smpl_joint_order} "
+            f"smpl_waist_yaw_offset_deg={args.smpl_waist_yaw_offset_deg} "
+            f"smpl_wrist_mapping={args.smpl_wrist_mapping} "
+            f"smpl_human_joints_info_path={args.smpl_human_joints_info_path}"
+        )
     if args.startup_sleep_s > 0:
         time.sleep(float(args.startup_sleep_s))
 
@@ -787,6 +978,17 @@ class PublisherArgs:
     min_link_height: float = 0.01
     min_link_height_align_strategy: Literal["none", "per_frame", "bootstrap"] = "bootstrap"
     min_link_height_bootstrap_frames: int = 30
+    publish_smpl: bool = False
+    smpl_bind: str = "tcp://*:28702"
+    smpl_topic: str = "pose"
+    smpl_wire_format: Literal["json", "packed"] = "json"
+    smpl_protocol_version: int = 3
+    smpl_hwm: int = 1
+    smpl_conflate: bool = True
+    smpl_joint_order: Literal["isaac", "robot_cfg"] = "isaac"
+    smpl_waist_yaw_offset_deg: float = 0.0
+    smpl_wrist_mapping: Literal["official", "zero"] = "official"
+    smpl_human_joints_info_path: str = DEFAULT_HUMAN_JOINTS_INFO_PATH
     verbose: bool = False
 
 

--- a/sim2real/teleop/sonic_smpl_stream.py
+++ b/sim2real/teleop/sonic_smpl_stream.py
@@ -1,0 +1,534 @@
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any, Sequence
+
+import numpy as np
+from scipy.spatial.transform import Rotation as R
+
+from sim2real.utils.math import quat_conjugate, quat_mul, quat_rotate_inverse_numpy
+
+
+HEADER_SIZE = 1280
+SMPL_NUM_JOINTS = 24
+SMPL_NUM_POSE_JOINTS = 21
+SMPL_WAIST_JOINT_NAMES = ("Spine1", "Spine2", "Spine3")
+DEFAULT_HUMAN_JOINTS_INFO_PATH = (
+    "checkpoints/sonic_official_release/human/human_joints_info.pkl"
+)
+_HUMAN_JOINTS_INFO_CACHE: dict[str, tuple[np.ndarray, np.ndarray]] = {}
+
+DEFAULT_STANDING_SMPL_JOINTS = np.asarray(
+    [
+        [0.00, 0.00, 0.00],   # Pelvis
+        [0.00, 0.10, -0.10],  # Left_Hip
+        [0.00, -0.10, -0.10], # Right_Hip
+        [0.00, 0.00, 0.12],   # Spine1
+        [0.00, 0.10, -0.48],  # Left_Knee
+        [0.00, -0.10, -0.48], # Right_Knee
+        [0.00, 0.00, 0.28],   # Spine2
+        [0.00, 0.10, -0.86],  # Left_Ankle
+        [0.00, -0.10, -0.86], # Right_Ankle
+        [0.00, 0.00, 0.44],   # Spine3
+        [0.12, 0.10, -0.92],  # Left_Foot
+        [0.12, -0.10, -0.92], # Right_Foot
+        [0.00, 0.00, 0.58],   # Neck
+        [0.00, 0.14, 0.50],   # Left_Collar
+        [0.00, -0.14, 0.50],  # Right_Collar
+        [0.00, 0.00, 0.76],   # Head
+        [0.00, 0.24, 0.46],   # Left_Shoulder
+        [0.00, -0.24, 0.46],  # Right_Shoulder
+        [0.02, 0.26, 0.18],   # Left_Elbow
+        [0.02, -0.26, 0.18],  # Right_Elbow
+        [0.04, 0.25, -0.08],  # Left_Wrist
+        [0.04, -0.25, -0.08], # Right_Wrist
+        [0.05, 0.25, -0.16],  # Left_Hand
+        [0.05, -0.25, -0.16], # Right_Hand
+    ],
+    dtype=np.float32,
+)
+
+ISAAC_G1_JOINT_NAMES = (
+    "left_hip_pitch_joint",
+    "right_hip_pitch_joint",
+    "waist_yaw_joint",
+    "left_hip_roll_joint",
+    "right_hip_roll_joint",
+    "waist_roll_joint",
+    "left_hip_yaw_joint",
+    "right_hip_yaw_joint",
+    "waist_pitch_joint",
+    "left_knee_joint",
+    "right_knee_joint",
+    "left_shoulder_pitch_joint",
+    "right_shoulder_pitch_joint",
+    "left_ankle_pitch_joint",
+    "right_ankle_pitch_joint",
+    "left_shoulder_roll_joint",
+    "right_shoulder_roll_joint",
+    "left_ankle_roll_joint",
+    "right_ankle_roll_joint",
+    "left_shoulder_yaw_joint",
+    "right_shoulder_yaw_joint",
+    "left_elbow_joint",
+    "right_elbow_joint",
+    "left_wrist_roll_joint",
+    "right_wrist_roll_joint",
+    "left_wrist_pitch_joint",
+    "right_wrist_pitch_joint",
+    "left_wrist_yaw_joint",
+    "right_wrist_yaw_joint",
+)
+
+SMPL_PARENT_INDICES = (
+    -1,
+    0,
+    0,
+    0,
+    1,
+    2,
+    3,
+    4,
+    5,
+    6,
+    7,
+    8,
+    9,
+    9,
+    9,
+    12,
+    13,
+    14,
+    16,
+    17,
+    18,
+    19,
+    20,
+    22,
+)
+
+
+def dtype_code(array: np.ndarray) -> str:
+    dtype = np.dtype(array.dtype)
+    if dtype == np.float32:
+        return "f32"
+    if dtype == np.float64:
+        return "f64"
+    if dtype == np.int64:
+        return "i64"
+    if dtype == np.int32:
+        return "i32"
+    if dtype == np.bool_:
+        return "bool"
+    raise TypeError(f"Unsupported packed dtype: {dtype}")
+
+
+def pack_pose_message(
+    fields: dict[str, np.ndarray],
+    *,
+    topic: str = "pose",
+    version: int = 3,
+) -> bytes:
+    payload_parts: list[bytes] = []
+    field_headers: list[dict[str, object]] = []
+    for name, value in fields.items():
+        array = np.ascontiguousarray(value)
+        field_headers.append(
+            {
+                "name": str(name),
+                "dtype": dtype_code(array),
+                "shape": list(array.shape),
+            }
+        )
+        payload_parts.append(array.tobytes(order="C"))
+
+    header = {
+        "v": int(version),
+        "endian": "le" if sys.byteorder == "little" else "be",
+        "count": int(fields["frame_index"].shape[0]) if "frame_index" in fields else -1,
+        "fields": field_headers,
+    }
+    header_bytes = json.dumps(header, separators=(",", ":")).encode("utf-8")
+    if len(header_bytes) > HEADER_SIZE:
+        raise ValueError(
+            f"Packed header is {len(header_bytes)} bytes, exceeds {HEADER_SIZE}"
+        )
+    padded_header = header_bytes + (b"\x00" * (HEADER_SIZE - len(header_bytes)))
+    return topic.encode("utf-8") + padded_header + b"".join(payload_parts)
+
+
+def json_safe_payload(fields: dict[str, np.ndarray]) -> dict[str, object]:
+    return {name: np.asarray(value).tolist() for name, value in fields.items()}
+
+
+def normalize_quat_wxyz(quat: np.ndarray) -> np.ndarray:
+    quat = np.asarray(quat, dtype=np.float32).reshape(-1, 4)
+    norm = np.linalg.norm(quat, axis=-1, keepdims=True)
+    return (quat / np.maximum(norm, 1e-8)).reshape(-1, 4)
+
+
+def axis_angle_to_quat_wxyz(axis_angle: np.ndarray) -> np.ndarray:
+    quat_xyzw = R.from_rotvec(np.asarray(axis_angle, dtype=np.float32).reshape(-1, 3)).as_quat()
+    return normalize_quat_wxyz(quat_xyzw[:, [3, 0, 1, 2]].astype(np.float32))
+
+
+def quat_wxyz_to_axis_angle(quat: np.ndarray) -> np.ndarray:
+    quat = normalize_quat_wxyz(quat)
+    return R.from_quat(quat[:, [1, 2, 3, 0]]).as_rotvec().astype(np.float32)
+
+
+def smpl_root_ytoz_up(root_quat_y_up: np.ndarray) -> np.ndarray:
+    base_rot = axis_angle_to_quat_wxyz(np.asarray([[np.pi / 2.0, 0.0, 0.0]], dtype=np.float32))
+    root_quat_y_up = normalize_quat_wxyz(root_quat_y_up)
+    return normalize_quat_wxyz(
+        quat_mul(np.broadcast_to(base_rot, root_quat_y_up.shape), root_quat_y_up)
+    )
+
+
+def remove_smpl_base_rot(root_quat_wxyz: np.ndarray) -> np.ndarray:
+    base_rot = quat_conjugate(
+        np.asarray([[0.5, 0.5, 0.5, 0.5]], dtype=np.float32)
+    )
+    root_quat_wxyz = normalize_quat_wxyz(root_quat_wxyz)
+    return normalize_quat_wxyz(
+        quat_mul(root_quat_wxyz, np.broadcast_to(base_rot, root_quat_wxyz.shape))
+    )
+
+
+def load_human_joints_info(path: str | Path) -> tuple[np.ndarray, np.ndarray]:
+    resolved_path = Path(path).expanduser()
+    cache_key = str(resolved_path.resolve()) if resolved_path.exists() else str(resolved_path)
+    cached = _HUMAN_JOINTS_INFO_CACHE.get(cache_key)
+    if cached is not None:
+        return cached
+
+    if not resolved_path.exists():
+        raise FileNotFoundError(f"SMPL human joints info not found: {resolved_path}")
+
+    import torch
+
+    info = torch.load(str(resolved_path), map_location="cpu")
+    joints = np.asarray(info["J"].detach().cpu().numpy(), dtype=np.float32)
+    parents = np.asarray(info["parents_list"], dtype=np.int64)
+    if joints.shape != (55, 3):
+        raise ValueError(f"Expected human joint rest pose shape (55, 3), got {joints.shape}")
+    if parents.shape != (55,):
+        raise ValueError(f"Expected 55 human joint parents, got {parents.shape}")
+
+    _HUMAN_JOINTS_INFO_CACHE[cache_key] = (joints, parents)
+    return joints, parents
+
+
+def compute_human_joints_np(
+    body_pose: np.ndarray,
+    global_orient: np.ndarray,
+    human_joints_info_path: str | Path,
+) -> np.ndarray:
+    rest_joints, parents = load_human_joints_info(human_joints_info_path)
+    body_pose = np.asarray(body_pose, dtype=np.float32).reshape(-1, 63)
+    global_orient = np.asarray(global_orient, dtype=np.float32).reshape(body_pose.shape[0], 3)
+    other_pose = np.zeros((body_pose.shape[0], 99), dtype=np.float32)
+    full_pose = np.concatenate([global_orient, body_pose, other_pose], axis=-1)
+    rot_mats = R.from_rotvec(full_pose.reshape(-1, 3)).as_matrix().astype(np.float32)
+    rot_mats = rot_mats.reshape(body_pose.shape[0], 55, 3, 3)
+
+    rel_joints = np.broadcast_to(rest_joints, (body_pose.shape[0],) + rest_joints.shape).copy()
+    rel_joints[:, 1:, :] -= rel_joints[:, parents[1:], :]
+
+    global_rots = np.zeros_like(rot_mats)
+    posed_joints = np.zeros((body_pose.shape[0], 55, 3), dtype=np.float32)
+    for joint_idx, parent_idx in enumerate(parents):
+        if parent_idx < 0:
+            global_rots[:, joint_idx] = rot_mats[:, joint_idx]
+            posed_joints[:, joint_idx] = rel_joints[:, joint_idx]
+        else:
+            global_rots[:, joint_idx] = global_rots[:, parent_idx] @ rot_mats[:, joint_idx]
+            posed_joints[:, joint_idx] = (
+                posed_joints[:, parent_idx]
+                + np.einsum("bij,bj->bi", global_rots[:, parent_idx], rel_joints[:, joint_idx])
+            )
+
+    output_joint_index = np.concatenate([np.arange(22), np.asarray([39, 54])])
+    return posed_joints[:, output_joint_index].astype(np.float32, copy=False)
+
+
+def official_smpl_frame_from_pose(
+    smpl_pose: np.ndarray,
+    root_quat_y_up_wxyz: np.ndarray,
+    *,
+    human_joints_info_path: str | Path,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Match SONIC's process_smpl_joints output for policy observation fields."""
+    smpl_pose = np.asarray(smpl_pose, dtype=np.float32).reshape(SMPL_NUM_POSE_JOINTS, 3)
+    root_quat_z_up = smpl_root_ytoz_up(root_quat_y_up_wxyz.reshape(1, 4))
+    root_axis_angle_z_up = quat_wxyz_to_axis_angle(root_quat_z_up)
+    joints = compute_human_joints_np(
+        smpl_pose.reshape(1, -1),
+        root_axis_angle_z_up,
+        human_joints_info_path,
+    )[0]
+    body_quat_w = remove_smpl_base_rot(root_quat_z_up)[0]
+    root_quat = np.broadcast_to(body_quat_w.reshape(1, 4), joints.shape[:-1] + (4,))
+    smpl_joints_local = quat_rotate_inverse_numpy(root_quat, joints)
+    return smpl_joints_local.astype(np.float32, copy=False), body_quat_w.astype(np.float32)
+
+
+def pose_dict_to_arrays(
+    body_pose_dict: dict[str, list[Any]],
+    joint_names: Sequence[str],
+) -> tuple[np.ndarray, np.ndarray]:
+    if len(joint_names) < SMPL_NUM_JOINTS:
+        raise ValueError(
+            f"Expected at least {SMPL_NUM_JOINTS} XRobot body joints, got {len(joint_names)}"
+        )
+
+    pos = np.zeros((SMPL_NUM_JOINTS, 3), dtype=np.float32)
+    quat_wxyz = np.zeros((SMPL_NUM_JOINTS, 4), dtype=np.float32)
+    for idx, name in enumerate(joint_names[:SMPL_NUM_JOINTS]):
+        if name not in body_pose_dict:
+            raise KeyError(f"Missing XRobot body joint '{name}'")
+        raw_pos, raw_quat = body_pose_dict[name]
+        pos[idx] = np.asarray(raw_pos, dtype=np.float32).reshape(3)
+        quat_wxyz[idx] = np.asarray(raw_quat, dtype=np.float32).reshape(4)
+    return pos, normalize_quat_wxyz(quat_wxyz)
+
+
+def local_axis_angle_from_global_quats(global_quat_wxyz: np.ndarray) -> np.ndarray:
+    global_quat_wxyz = normalize_quat_wxyz(global_quat_wxyz)
+    global_rot = R.from_quat(global_quat_wxyz[:, [1, 2, 3, 0]])
+    local_axis_angle = np.zeros((SMPL_NUM_JOINTS, 3), dtype=np.float32)
+    for idx, parent_idx in enumerate(SMPL_PARENT_INDICES):
+        if parent_idx < 0:
+            local_rot = global_rot[idx]
+        else:
+            local_rot = global_rot[parent_idx].inv() * global_rot[idx]
+        local_axis_angle[idx] = local_rot.as_rotvec().astype(np.float32)
+    return local_axis_angle
+
+
+def apply_local_yaw_offset(
+    local_axis_angle: np.ndarray,
+    joint_names: Sequence[str],
+    target_joint_names: Sequence[str],
+    yaw_offset_deg: float,
+) -> np.ndarray:
+    if abs(float(yaw_offset_deg)) < 1e-6:
+        return np.asarray(local_axis_angle, dtype=np.float32)
+
+    out = np.asarray(local_axis_angle, dtype=np.float32).copy()
+    name_to_idx = {str(name): idx for idx, name in enumerate(joint_names[:SMPL_NUM_JOINTS])}
+    offset_rot = R.from_euler("z", float(yaw_offset_deg), degrees=True)
+    for joint_name in target_joint_names:
+        joint_idx = name_to_idx.get(str(joint_name))
+        if joint_idx is None or joint_idx >= out.shape[0]:
+            continue
+        local_rot = R.from_rotvec(out[joint_idx])
+        out[joint_idx] = (local_rot * offset_rot).as_rotvec().astype(np.float32)
+    return out
+
+
+def root_local_positions(body_pos_w: np.ndarray, root_quat_wxyz: np.ndarray) -> np.ndarray:
+    root_pos = body_pos_w[0:1]
+    rel = body_pos_w - root_pos
+    root_quat = np.broadcast_to(root_quat_wxyz.reshape(1, 4), rel.shape[:-1] + (4,))
+    return quat_rotate_inverse_numpy(root_quat, rel).astype(np.float32, copy=False)
+
+
+def decompose_rotation_aa(
+    axis_angle: np.ndarray,
+    twist_axis: np.ndarray,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Decompose axis-angle rotations into twist and swing quaternions.
+
+    Returns quaternions in wxyz order, matching the official SONIC wrist mapping
+    call sites.
+    """
+    axis_angle = np.asarray(axis_angle, dtype=np.float32).reshape(-1, 3)
+    twist_axis = np.asarray(twist_axis, dtype=np.float32).reshape(3)
+    twist_axis = twist_axis / max(float(np.linalg.norm(twist_axis)), 1e-8)
+
+    quat_xyzw = R.from_rotvec(axis_angle).as_quat()
+    quat_wxyz = quat_xyzw[:, [3, 0, 1, 2]].astype(np.float32)
+    q_vec = quat_wxyz[:, 1:]
+    projected = np.sum(q_vec * twist_axis.reshape(1, 3), axis=1, keepdims=True)
+    twist_vec = projected * twist_axis.reshape(1, 3)
+    twist = np.concatenate([quat_wxyz[:, 0:1], twist_vec], axis=1)
+    twist = normalize_quat_wxyz(twist)
+    swing = quat_mul(quat_wxyz, quat_conjugate(twist)).astype(np.float32, copy=False)
+    return twist.astype(np.float32, copy=False), swing
+
+
+def g1_wrist_joint_pos_from_smpl_pose(
+    smpl_pose: np.ndarray,
+    *,
+    joint_names: Sequence[str] = ISAAC_G1_JOINT_NAMES,
+    mode: str = "official",
+) -> np.ndarray:
+    """Map SMPL elbow/wrist rotations to G1 wrist joints.
+
+    This is an equivalent port of the wrist mapping used by SONIC's official
+    PICO manager. Only the six wrist joints are filled; all other joints are 0.
+    """
+    body_pose = np.asarray(smpl_pose, dtype=np.float32).reshape(-1, SMPL_NUM_POSE_JOINTS, 3)
+    if mode == "zero":
+        joint_pos = np.zeros((body_pose.shape[0], len(joint_names)), dtype=np.float32)
+        return joint_pos[0] if np.asarray(smpl_pose).ndim == 2 else joint_pos
+    if mode != "official":
+        raise ValueError(f"Unsupported wrist joint mapping mode: {mode}")
+
+    smpl_l_elbow = body_pose[:, 17]
+    smpl_l_wrist = body_pose[:, 19]
+    smpl_r_elbow = body_pose[:, 18]
+    smpl_r_wrist = body_pose[:, 20]
+
+    _, l_elbow_swing = decompose_rotation_aa(smpl_l_elbow, np.array([0.0, 1.0, 0.0]))
+    _, r_elbow_swing = decompose_rotation_aa(smpl_r_elbow, np.array([0.0, 1.0, 0.0]))
+
+    l_elbow_swing_euler = R.from_quat(l_elbow_swing[:, [1, 2, 3, 0]]).as_euler(
+        "XYZ", degrees=False
+    )
+    r_elbow_swing_euler = R.from_quat(r_elbow_swing[:, [1, 2, 3, 0]]).as_euler(
+        "XYZ", degrees=False
+    )
+    l_wrist_euler = R.from_rotvec(smpl_l_wrist).as_euler("XYZ", degrees=False)
+    r_wrist_euler = R.from_rotvec(smpl_r_wrist).as_euler("XYZ", degrees=False)
+
+    values = {
+        "left_wrist_roll_joint": l_elbow_swing_euler[:, 0] + l_wrist_euler[:, 0],
+        "left_wrist_pitch_joint": l_wrist_euler[:, 1],
+        "left_wrist_yaw_joint": l_elbow_swing_euler[:, 2] + l_wrist_euler[:, 2],
+        "right_wrist_roll_joint": -(r_elbow_swing_euler[:, 0] + r_wrist_euler[:, 0]),
+        "right_wrist_pitch_joint": -r_wrist_euler[:, 1],
+        "right_wrist_yaw_joint": r_elbow_swing_euler[:, 2] + r_wrist_euler[:, 2],
+    }
+
+    joint_pos = np.zeros((body_pose.shape[0], len(joint_names)), dtype=np.float32)
+    name_to_idx = {name: idx for idx, name in enumerate(joint_names)}
+    for name, value in values.items():
+        if name in name_to_idx:
+            joint_pos[:, name_to_idx[name]] = value.astype(np.float32, copy=False)
+    return joint_pos[0] if np.asarray(smpl_pose).ndim == 2 else joint_pos
+
+
+def build_smpl_frame(
+    body_pose_dict: dict[str, list[Any]],
+    joint_names: Sequence[str],
+    *,
+    g1_joint_names: Sequence[str] = ISAAC_G1_JOINT_NAMES,
+    waist_yaw_offset_deg: float = 0.0,
+    wrist_mapping_mode: str = "official",
+) -> dict[str, np.ndarray]:
+    body_pos_w, body_quat_wxyz = pose_dict_to_arrays(body_pose_dict, joint_names)
+    local_axis_angle = local_axis_angle_from_global_quats(body_quat_wxyz)
+    local_axis_angle = apply_local_yaw_offset(
+        local_axis_angle,
+        joint_names,
+        SMPL_WAIST_JOINT_NAMES,
+        waist_yaw_offset_deg,
+    )
+    smpl_pose = local_axis_angle[1 : 1 + SMPL_NUM_POSE_JOINTS]
+    smpl_joints = root_local_positions(body_pos_w, body_quat_wxyz[0])
+    joint_pos = g1_wrist_joint_pos_from_smpl_pose(
+        smpl_pose,
+        joint_names=tuple(g1_joint_names),
+        mode=wrist_mapping_mode,
+    )
+    return {
+        "smpl_pose": smpl_pose.astype(np.float32, copy=False),
+        "smpl_joints": smpl_joints.astype(np.float32, copy=False),
+        "body_quat_w": body_quat_wxyz[0].astype(np.float32, copy=False),
+        "joint_pos": np.asarray(joint_pos, dtype=np.float32),
+    }
+
+
+def smpl_pose_from_xrobot_raw(body_poses: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+    """Compute SONIC-style SMPL local pose from raw XRobot SDK body poses.
+
+    ``body_poses`` is expected in the raw XRobot layout
+    ``[x, y, z, qx, qy, qz, qw]``. This follows SONIC's official
+    ``compute_from_body_poses`` path for the local rotations.
+    """
+    body_poses = np.asarray(body_poses, dtype=np.float32)
+    if body_poses.shape[0] < SMPL_NUM_JOINTS or body_poses.shape[1] < 7:
+        raise ValueError(f"Expected raw XRobot body poses [>=24, >=7], got {body_poses.shape}")
+
+    global_quat_wxyz = normalize_quat_wxyz(body_poses[:SMPL_NUM_JOINTS, [6, 3, 4, 5]])
+    global_rots = R.from_quat(global_quat_wxyz[:, [1, 2, 3, 0]])
+    global_rots = global_rots * R.from_euler("y", 180, degrees=True)
+
+    local_axis_angle = np.zeros((SMPL_NUM_JOINTS, 3), dtype=np.float32)
+    for idx, parent_idx in enumerate(SMPL_PARENT_INDICES):
+        if parent_idx < 0:
+            local_rot = global_rots[idx]
+        else:
+            local_rot = global_rots[parent_idx].inv() * global_rots[idx]
+        local_axis_angle[idx] = local_rot.as_rotvec().astype(np.float32)
+
+    root_quat_xyzw = global_rots[0].as_quat()
+    root_quat_wxyz = root_quat_xyzw[[3, 0, 1, 2]].astype(np.float32)
+    return local_axis_angle[1 : 1 + SMPL_NUM_POSE_JOINTS], root_quat_wxyz
+
+
+def root_local_positions_from_xrobot_raw(
+    body_poses: np.ndarray,
+    root_quat_wxyz: np.ndarray,
+) -> np.ndarray:
+    body_poses = np.asarray(body_poses, dtype=np.float32)
+    if body_poses.shape[0] < SMPL_NUM_JOINTS or body_poses.shape[1] < 3:
+        raise ValueError(f"Expected raw XRobot body poses [>=24, >=3], got {body_poses.shape}")
+
+    body_pos_w = body_poses[:SMPL_NUM_JOINTS, :3].astype(np.float32, copy=False)
+    return root_local_positions(body_pos_w, root_quat_wxyz)
+
+
+def build_smpl_frame_from_xrobot_raw(
+    body_poses: np.ndarray,
+    body_pose_dict_for_joints: dict[str, list[Any]],
+    joint_names: Sequence[str],
+    *,
+    g1_joint_names: Sequence[str] = ISAAC_G1_JOINT_NAMES,
+    waist_yaw_offset_deg: float = 0.0,
+    wrist_mapping_mode: str = "official",
+    human_joints_info_path: str | Path | None = DEFAULT_HUMAN_JOINTS_INFO_PATH,
+) -> dict[str, np.ndarray]:
+    smpl_pose, root_quat_wxyz = smpl_pose_from_xrobot_raw(body_poses)
+    if abs(float(waist_yaw_offset_deg)) >= 1e-6:
+        local_axis_angle = np.zeros((SMPL_NUM_JOINTS, 3), dtype=np.float32)
+        local_axis_angle[1 : 1 + SMPL_NUM_POSE_JOINTS] = smpl_pose
+        local_axis_angle = apply_local_yaw_offset(
+            local_axis_angle,
+            joint_names,
+            SMPL_WAIST_JOINT_NAMES,
+            waist_yaw_offset_deg,
+        )
+        smpl_pose = local_axis_angle[1 : 1 + SMPL_NUM_POSE_JOINTS]
+
+    body_quat_w = root_quat_wxyz.astype(np.float32, copy=False)
+    if human_joints_info_path:
+        try:
+            smpl_joints, body_quat_w = official_smpl_frame_from_pose(
+                smpl_pose,
+                root_quat_wxyz,
+                human_joints_info_path=human_joints_info_path,
+            )
+        except (FileNotFoundError, KeyError, ValueError, ImportError, ModuleNotFoundError):
+            smpl_joints = root_local_positions_from_xrobot_raw(body_poses, root_quat_wxyz)
+    else:
+        try:
+            smpl_joints = root_local_positions_from_xrobot_raw(body_poses, root_quat_wxyz)
+        except ValueError:
+            body_pos_w, _body_quat_wxyz = pose_dict_to_arrays(body_pose_dict_for_joints, joint_names)
+            smpl_joints = root_local_positions(body_pos_w, root_quat_wxyz)
+    joint_pos = g1_wrist_joint_pos_from_smpl_pose(
+        smpl_pose,
+        joint_names=tuple(g1_joint_names),
+        mode=wrist_mapping_mode,
+    )
+    return {
+        "smpl_pose": smpl_pose.astype(np.float32, copy=False),
+        "smpl_joints": smpl_joints.astype(np.float32, copy=False),
+        "body_quat_w": body_quat_w.astype(np.float32, copy=False),
+        "joint_pos": np.asarray(joint_pos, dtype=np.float32),
+    }


### PR DESCRIPTION
# fix sonic & twist2 support

## Summary

这个 PR 主要修复和补齐 SONIC / TWIST2 在 sim2real runtime 里的支持，包括 TWIST2 的 upstream Unitree I/O 路径、ZMQ motion 的速度字段补全，以及 SONIC 的 SMPL stream / realtime motion 支持。

## Changes

- 新增 `real_io_backend="upstream"` 路径：
  - 通过 `unitree_interface` 直接读取 G1 low state、发送 low cmd
  - 默认仍然走原来的 ZMQ bridge
  - 新增 `--robot_interface` 用于指定 Unitree 通信网卡

- 修复 TWIST2 realtime ZMQ motion 支持：
  - `RealtimeMotionBuffer` 现在会从相邻 motion frame 估算：
    - `joint_vel`
    - `body_lin_vel_w`
    - `body_ang_vel_w`
  - TWIST2 observation 会使用 root linear/angular velocity，因此 ZMQ motion 不再退化为零速度输入

- 补充 SONIC / SMPL realtime 支持：
  - 新增 SMPL motion buffer
  - 支持 `motion_backend=smpl_zmq`
  - Pico teleop 可发布 SMPL stream
  - SONIC observation 支持 official SMPL encoder input

- 改进 tracking runtime motion 配置：
  - 支持运行时覆盖 `motion_backend`
  - 支持 `npz` / `zmq` / `smpl_zmq`
  - 保留必要的 ZMQ connect / HWM / tolerance 参数

- 改进 TensorRT import 行为：
  - 仅在实际选择 `inference_backend="tensorrt"` 时加载 TensorRT module
  - 避免非 TensorRT 路径因为环境缺 TensorRT 直接失败

- 清理本地临时产物：
  - ignore Hugging Face cache、临时对比目录、输出 npz 等本地文件

## Usage examples

### TWIST2

#### Sim2real teleop

运行 TWIST2 tracking，motion 通过 Pico retarget ZMQ stream 输入，真实机器人 I/O 走 upstream Unitree interface：

```bash
uv run sim2real/rl_policy/tracking.py \
  --robot g1 \
  --policy_config checkpoints/twist2/policy-twist2_1017_20k.yaml \
  --motion_backend zmq \
  --motion_zmq_connect tcp://127.0.0.1:28701 \
  --controller pico \
  --pico_zmq_connect tcp://127.0.0.1:5592 \
  --real_io_backend upstream \
  --robot_interface eth0
```

启动 Pico retarget publisher，向 tracking 发送 motion stream 和 controller state：

```bash
uv --project venv/teleop run sim2real/teleop/pico_retarget_pub.py \
  --robot g1 \
  --bind tcp://*:28701 \
  --controller_bind tcp://*:5592 \
  --publish_hz 50 \
  --actual_human_height 1.80
```

注意：第一次使用 upstream real I/O 路径时，建议先启动原来的 real bridge 并进入调试模式，确认机器人 low state / low cmd 通信、急停和控制链路都正常，再切到 `real_io_backend="upstream"`。

#### ZMQ sim bridge

启动基础仿真：

```bash
uv run sim2real/sim_env/base_sim.py \
  --robot g1 \
  --sim_dt 0.001 \
  --decimation 20
```

通过 ZMQ bridge 运行 TWIST2 tracking：

```bash
uv run sim2real/rl_policy/tracking.py \
  --robot g1 \
  --controller keyboard \
  --inference_backend onnx-cpu \
  --rl_rate 50 \
  --policy_config checkpoints/twist2/policy-twist2_1017_20k.yaml \
  --motion_backend npz \
  --motion_path /path/to/motion.npz \
  --real_io_backend zmq
```

### SONIC

#### Retarget realtime stream

运行 SONIC release policy，motion 通过 Pico retarget ZMQ stream 输入：

```bash
uv run sim2real/rl_policy/tracking.py \
  --robot g1 \
  --policy_config checkpoints/sonic_release/policy-sonic-release.yaml \
  --motion_backend zmq \
  --motion_zmq_connect tcp://127.0.0.1:28701 \
  --controller pico \
  --pico_zmq_connect tcp://127.0.0.1:5592 \
  --real_io_backend zmq \
  --inference_backend onnx-cpu
```

启动 Pico retarget publisher，向 tracking 发送 retarget motion stream 和 controller state：

```bash
uv --project venv/teleop run sim2real/teleop/pico_retarget_pub.py \
  --robot g1 \
  --bind tcp://*:28701 \
  --controller_bind tcp://*:5592 \
  --publish_hz 50 \
  --actual_human_height 1.80
```

#### SMPL realtime stream

运行 SONIC official policy，motion 通过 Pico retarget 发布的 SMPL ZMQ stream 输入：

```bash
uv run sim2real/rl_policy/tracking.py \
  --robot g1 \
  --policy_config checkpoints/sonic_official_release/policy/release/policy-sonic-official-merged-unbatched.yaml \
  --motion_backend smpl_zmq \
  --motion_zmq_connect tcp://127.0.0.1:28702 \
  --controller pico \
  --pico_zmq_connect tcp://127.0.0.1:5592 \
  --real_io_backend zmq \
  --inference_backend onnx-cpu
```

启动 Pico retarget publisher，并同时发布 SMPL stream：

```bash
uv --project venv/teleop run sim2real/teleop/pico_retarget_pub.py \
  --robot g1 \
  --bind tcp://*:28701 \
  --controller_bind tcp://*:5592 \
  --publish_hz 50 \
  --actual_human_height 1.80 \
  --publish_smpl True \
  --smpl_bind tcp://*:28702
```

#### ZMQ sim bridge

启动基础仿真：

```bash
uv run sim2real/sim_env/base_sim.py \
  --robot g1
```

通过 ZMQ bridge 运行 SONIC tracking：

```bash
uv run sim2real/rl_policy/tracking.py \
  --robot g1 \
  --controller keyboard \
  --inference_backend onnx-cpu \
  --rl_rate 50 \
  --policy_config checkpoints/sonic_release/policy-sonic-release.yaml \
  --motion_backend npz \
  --motion_path /path/to/motion.npz \
  --real_io_backend zmq
```

注意：SONIC 会使用最多 45 帧的 future motion command。50 Hz 下这对应 0.9 s 的 future window。切入 policy 模式时，机器人当前状态和 reference motion 可能没有完全对齐，因此第一次进入 policy 时可能不稳定。可以 reset sim，并多尝试几次 init / policy 切换。

## TODO

- 重新测试 cleanup 后的 sim2real runtime，确认 TWIST2 / SONIC 的 ZMQ bridge、upstream real I/O 和 teleop 链路都仍然正常。
- 考虑合并两类真实机器人 I/O interface：原来的 real bridge 路径和新的 upstream `unitree_interface` 路径，减少后续维护分叉；或者给 upstream 路径补一个调试模式入口，方便替代原 real bridge 的调试流程。
- 修复 SMPL 模式下 default pose / default joint position 的问题：当前默认姿态里头部和肩膀会有些偏歪，后续需要校准 SMPL default pose、上半身 joint mapping / offset，以及对应的 G1 default joint position。
- G1 上如果 `checkpoints/twist2` 里还有三套 TWIST2 checkpoint，可以和本地保持一致：删除 default / realsafe 两套，只保留 upstreamreal 这一套，并重命名为默认无后缀文件名：

```bash
rm checkpoints/twist2/policy-twist2_1017_20k.{yaml,onnx,json}
rm checkpoints/twist2/policy-twist2_1017_20k_realsafe.{yaml,onnx,json}
mv checkpoints/twist2/policy-twist2_1017_20k_upstreamreal.yaml checkpoints/twist2/policy-twist2_1017_20k.yaml
mv checkpoints/twist2/policy-twist2_1017_20k_upstreamreal.onnx checkpoints/twist2/policy-twist2_1017_20k.onnx
mv checkpoints/twist2/policy-twist2_1017_20k_upstreamreal.json checkpoints/twist2/policy-twist2_1017_20k.json
```

## Summary by Sourcery

Add upstream Unitree I/O backend and SMPL ZMQ motion streaming to support SONIC and TWIST2 sim2real runtimes, while relaxing TensorRT as a hard dependency.

New Features:
- Introduce a realtime SMPL motion buffer and data structure for consuming SMPL ZMQ motion streams.
- Enable Pico teleop to publish SMPL-based motion streams, including packed and JSON wire formats, for G1 wrist and SMPL joint control.
- Add SONIC-specific SMPL encoder observation that constructs the official encoder input from realtime SMPL motion data.
- Support an upstream G1 real I/O backend that talks directly to Unitree via unitree_interface, selectable at runtime.
- Allow tracking runtime to choose between npz, ZMQ, and SMPL ZMQ motion backends via CLI arguments.

Bug Fixes:
- Populate joint and body linear/angular velocities in realtime ZMQ motion observations by estimating them from adjacent frames, fixing zero-velocity TWIST2 inputs.
- Make TWIST2 encoder history reset to zeros instead of stale values to avoid polluted initial observations.
- Handle temporary MJCF scene cleanup failures caused by permission errors without crashing.

Enhancements:
- Compute SMPL-based wrist joint commands and heading-aligned SMPL frames from XRobot input, including optional waist yaw offsets and human-joint-based SMPL joints.
- Extend SONIC motion observations to work with realtime motion backends (ZMQ / SMPL ZMQ) in addition to npz datasets.
- Refine SONIC encoder index observation to carry a mode identifier and add a dedicated SMPL mode ID for the official encoder.
- Gate TensorRT module import behind a runtime check on the selected inference backend to avoid failures when TensorRT is absent.
- Improve Pico teleop debug printing and timing metrics to cover SMPL publishing paths.
- Allow StateProcessor and ActionManager to optionally bypass ZMQ and use the upstream real I/O backend for low-state reads and command sends.

Build:
- Ignore additional local artifacts such as Hugging Face caches and temporary comparison/output files in version control.