### PR TITLE
Add ZMQ NPZ motion publisher

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,8 +13,6 @@ dependencies = [
     "pyyaml",
     "scipy",
     "torch",
-    "onnxruntime",
-    # "onnxruntime-gpu",
     "onnx==1.17.0",
     "sshkeyboard",
     "pyzmq",
@@ -25,7 +23,15 @@ dependencies = [
 ]
 
 [dependency-groups]
+cpu = [
+    "onnxruntime",
+]
 g1 = [
+    "unitree-interface==0.1.0; sys_platform == 'linux' and platform_machine == 'aarch64'",
+]
+g1-gpu = [
+    "numpy<2",
+    "onnxruntime-gpu==1.16.0; sys_platform == 'linux' and platform_machine == 'aarch64'",
     "unitree-interface==0.1.0; sys_platform == 'linux' and platform_machine == 'aarch64'",
 ]
 
@@ -57,4 +63,4 @@ explicit = true
 
 [tool.uv.sources]
 tensorrt = { index = "nvidia-pypi" }
-onnxruntime-gpu = { index = "jetson-ai-lab-jp6-cu126" }
+onnxruntime-gpu = { path = "tmp_wheels/onnxruntime_gpu-1.16.0-cp310-cp310-linux_aarch64.whl" }

--- a/sim2real/rl_policy/tracking.py
+++ b/sim2real/rl_policy/tracking.py
@@ -65,6 +65,7 @@ def _apply_runtime_motion_config(
     motion_zmq_hwm: int,
     motion_dt_s: float,
     motion_tolerance_s: float,
+    motion_reconnect_reset_s: float,
 ):
     policy_config = deepcopy(policy_config)
     motion_cfg = policy_config.setdefault("motion", {})
@@ -95,6 +96,7 @@ def _apply_runtime_motion_config(
         motion_cfg["motion_zmq_hwm"] = motion_zmq_hwm
         motion_cfg["motion_dt_s"] = motion_dt_s
         motion_cfg["motion_tolerance_s"] = motion_tolerance_s
+        motion_cfg["motion_reconnect_reset_s"] = motion_reconnect_reset_s
 
     return policy_config
 
@@ -111,6 +113,7 @@ class Tracking(BasePolicy):
             motion_zmq_hwm=self.args.motion_zmq_hwm,
             motion_dt_s=1 / self.args.rl_rate,
             motion_tolerance_s=self.args.motion_tolerance_s,
+            motion_reconnect_reset_s=self.args.motion_reconnect_reset_s,
         )
         motion_cfg = policy_config.get("motion", {})
         resolved_backend = str(motion_cfg.get("motion_backend", ""))
@@ -125,6 +128,20 @@ class Tracking(BasePolicy):
         paused = not bool(self.state_dict.get("paused", False))
         self.state_dict["paused"] = paused
         logger.info(f"Paused state toggled to {paused} via {source}")
+
+    def _reset_observations_after_motion_reconnect(self) -> None:
+        logger.info("Resetting tracking observations after motion stream reconnect")
+        for obs_group in self.observations.values():
+            for obs_func in obs_group.funcs.values():
+                obs_func.reset()
+
+    def update(self):
+        self.state_processor.update(self.state_dict)
+        if self.state_processor.consume_motion_stream_reconnected():
+            self._reset_observations_after_motion_reconnect()
+        for obs_group in self.observations.values():
+            for obs_func in obs_group.funcs.values():
+                obs_func.update(self.state_dict)
 
     def process_controllers(self) -> None:
         super().process_controllers()
@@ -148,6 +165,7 @@ class TrackingArgs(BasePolicyArgs):
     motion_zmq_connect: Optional[str] = None
     motion_zmq_hwm: int = 1
     motion_tolerance_s: float = 0.04
+    motion_reconnect_reset_s: float = 0.5
 
 
 if __name__ == "__main__":

--- a/sim2real/rl_policy/utils/motion_buffer.py
+++ b/sim2real/rl_policy/utils/motion_buffer.py
@@ -84,6 +84,7 @@ class RealtimeMotionBuffer:
         motion_zmq_hwm: int = 1,
         dt_s: float = 0.02,
         tolerance_s: float = 0.04,
+        reconnect_timeout_s: float = 0.5,
     ):
         self.robot_cfg = robot_cfg
         if dt_s <= 0.0:
@@ -97,6 +98,7 @@ class RealtimeMotionBuffer:
             raise ValueError(f"future_steps must be 1D, got {self.future_steps.shape}")
         self.dt_s = float(dt_s)
         self.tolerance_s = float(tolerance_s)
+        self.reconnect_timeout_s = float(reconnect_timeout_s)
         self.min_future_step = int(np.min(self.future_steps)) if self.future_steps.size else 0
         self.max_future_step = int(np.max(self.future_steps)) if self.future_steps.size else 0
         self._dt_ns = int(self.dt_s * 1e9)
@@ -110,8 +112,13 @@ class RealtimeMotionBuffer:
         self._lock = threading.Lock()
         self._timestamps_ns: list[int] = []
         self._joint_pos_frames: list[np.ndarray] = []
+        self._joint_vel_frames: list[np.ndarray | None] = []
         self._body_pos_w_frames: list[np.ndarray] = []
+        self._body_lin_vel_w_frames: list[np.ndarray | None] = []
         self._body_quat_w_frames: list[np.ndarray] = []
+        self._body_ang_vel_w_frames: list[np.ndarray | None] = []
+        self._last_payload_recv_monotonic: float | None = None
+        self._stream_reconnected = False
         self._motion_id_template = np.zeros((1, self.future_steps.shape[0]), dtype=np.int64)
         self._step_template = self.future_steps.reshape(1, -1)
         self._zmq_context = zmq.Context.instance()
@@ -212,24 +219,69 @@ class RealtimeMotionBuffer:
             body_quat_w.astype(np.float32, copy=False),
             eps=1e-8,
         ).astype(np.float32, copy=True)
+        joint_vel_frame: np.ndarray | None = None
+        body_lin_vel_w_frame: np.ndarray | None = None
+        body_ang_vel_w_frame: np.ndarray | None = None
+        has_velocity_payload = all(
+            key in payload for key in ("joint_vel", "body_lin_vel_w", "body_ang_vel_w")
+        )
+        if has_velocity_payload:
+            joint_vel = _ensure_np(payload["joint_vel"], 1)
+            body_lin_vel_w = _ensure_np(payload["body_lin_vel_w"], 2)
+            body_ang_vel_w = _ensure_np(payload["body_ang_vel_w"], 2)
+            if joint_vel.shape != (self._num_joints,):
+                raise ValueError(f"Expected joint_vel ({self._num_joints},), got {joint_vel.shape}")
+            if body_lin_vel_w.shape != (self._num_bodies, 3):
+                raise ValueError(
+                    f"Expected body_lin_vel_w ({self._num_bodies}, 3), got {body_lin_vel_w.shape}"
+                )
+            if body_ang_vel_w.shape != (self._num_bodies, 3):
+                raise ValueError(
+                    f"Expected body_ang_vel_w ({self._num_bodies}, 3), got {body_ang_vel_w.shape}"
+                )
+            joint_vel_frame = joint_vel.astype(np.float32, copy=True)
+            body_lin_vel_w_frame = body_lin_vel_w.astype(np.float32, copy=True)
+            body_ang_vel_w_frame = body_ang_vel_w.astype(np.float32, copy=True)
 
+        recv_monotonic = time.monotonic()
         with self._lock:
+            if (
+                self._last_payload_recv_monotonic is not None
+                and self.reconnect_timeout_s > 0.0
+                and recv_monotonic - self._last_payload_recv_monotonic
+                > self.reconnect_timeout_s
+            ):
+                self._stream_reconnected = True
+            self._last_payload_recv_monotonic = recv_monotonic
+
             if not self._timestamps_ns or timestamp_ns >= self._timestamps_ns[-1]:
                 self._timestamps_ns.append(timestamp_ns)
                 self._joint_pos_frames.append(joint_pos_frame)
+                self._joint_vel_frames.append(joint_vel_frame)
                 self._body_pos_w_frames.append(body_pos_w_frame)
+                self._body_lin_vel_w_frames.append(body_lin_vel_w_frame)
                 self._body_quat_w_frames.append(body_quat_w_frame)
+                self._body_ang_vel_w_frames.append(body_ang_vel_w_frame)
             else:
                 insert_idx = bisect_right(self._timestamps_ns, timestamp_ns)
                 self._timestamps_ns.insert(insert_idx, timestamp_ns)
                 self._joint_pos_frames.insert(insert_idx, joint_pos_frame)
+                self._joint_vel_frames.insert(insert_idx, joint_vel_frame)
                 self._body_pos_w_frames.insert(insert_idx, body_pos_w_frame)
+                self._body_lin_vel_w_frames.insert(insert_idx, body_lin_vel_w_frame)
                 self._body_quat_w_frames.insert(insert_idx, body_quat_w_frame)
+                self._body_ang_vel_w_frames.insert(insert_idx, body_ang_vel_w_frame)
 
     @property
     def latest_timestamp_ns(self) -> int | None:
         with self._lock:
             return self._timestamps_ns[-1] if self._timestamps_ns else None
+
+    def consume_stream_reconnected(self) -> bool:
+        with self._lock:
+            reconnected = self._stream_reconnected
+            self._stream_reconnected = False
+        return reconnected
 
     def _fill_sample_frames_locked(
         self,
@@ -252,11 +304,20 @@ class RealtimeMotionBuffer:
 
         if len(self._timestamps_ns) == 1:
             joint_pos_out[:] = self._joint_pos_frames[0]
-            joint_vel_out.fill(0.0)
+            if self._joint_vel_frames[0] is not None:
+                joint_vel_out[:] = self._joint_vel_frames[0]
+            else:
+                joint_vel_out.fill(0.0)
             body_pos_w_out[:] = self._body_pos_w_frames[0]
-            body_lin_vel_w_out.fill(0.0)
+            if self._body_lin_vel_w_frames[0] is not None:
+                body_lin_vel_w_out[:] = self._body_lin_vel_w_frames[0]
+            else:
+                body_lin_vel_w_out.fill(0.0)
             body_quat_w_out[:] = self._body_quat_w_frames[0]
-            body_ang_vel_w_out.fill(0.0)
+            if self._body_ang_vel_w_frames[0] is not None:
+                body_ang_vel_w_out[:] = self._body_ang_vel_w_frames[0]
+            else:
+                body_ang_vel_w_out.fill(0.0)
             return
 
         timestamps_ns = np.asarray(self._timestamps_ns, dtype=np.int64)
@@ -284,6 +345,33 @@ class RealtimeMotionBuffer:
             out=np.zeros_like(joint_vel_out),
             where=dt_s > 0.0,
         )
+        joint_vel_available = [
+            self._joint_vel_frames[left_idx] is not None
+            and self._joint_vel_frames[right_idx] is not None
+            for left_idx, right_idx in zip(left, right, strict=True)
+        ]
+        if any(joint_vel_available):
+            joint_vel_left = np.stack(
+                [
+                    self._joint_vel_frames[idx]
+                    if self._joint_vel_frames[idx] is not None
+                    else np.zeros(self._num_joints, dtype=np.float32)
+                    for idx in left
+                ],
+                axis=0,
+            )
+            joint_vel_right = np.stack(
+                [
+                    self._joint_vel_frames[idx]
+                    if self._joint_vel_frames[idx] is not None
+                    else np.zeros(self._num_joints, dtype=np.float32)
+                    for idx in right
+                ],
+                axis=0,
+            )
+            mask = np.asarray(joint_vel_available, dtype=bool)
+            joint_vel_lerp = joint_vel_left + alpha_joint * (joint_vel_right - joint_vel_left)
+            joint_vel_out[mask] = joint_vel_lerp[mask]
 
         body_pos_left = np.stack([self._body_pos_w_frames[idx] for idx in left], axis=0)
         body_pos_right = np.stack([self._body_pos_w_frames[idx] for idx in right], axis=0)
@@ -296,6 +384,35 @@ class RealtimeMotionBuffer:
             out=np.zeros_like(body_lin_vel_w_out),
             where=dt_body_s > 0.0,
         )
+        body_lin_vel_available = [
+            self._body_lin_vel_w_frames[left_idx] is not None
+            and self._body_lin_vel_w_frames[right_idx] is not None
+            for left_idx, right_idx in zip(left, right, strict=True)
+        ]
+        if any(body_lin_vel_available):
+            body_lin_vel_left = np.stack(
+                [
+                    self._body_lin_vel_w_frames[idx]
+                    if self._body_lin_vel_w_frames[idx] is not None
+                    else np.zeros((self._num_bodies, 3), dtype=np.float32)
+                    for idx in left
+                ],
+                axis=0,
+            )
+            body_lin_vel_right = np.stack(
+                [
+                    self._body_lin_vel_w_frames[idx]
+                    if self._body_lin_vel_w_frames[idx] is not None
+                    else np.zeros((self._num_bodies, 3), dtype=np.float32)
+                    for idx in right
+                ],
+                axis=0,
+            )
+            mask = np.asarray(body_lin_vel_available, dtype=bool)
+            body_lin_vel_lerp = body_lin_vel_left + alpha_body * (
+                body_lin_vel_right - body_lin_vel_left
+            )
+            body_lin_vel_w_out[mask] = body_lin_vel_lerp[mask]
 
         body_quat_left = np.stack([self._body_quat_w_frames[idx] for idx in left], axis=0)
         body_quat_right = np.stack([self._body_quat_w_frames[idx] for idx in right], axis=0)
@@ -311,6 +428,35 @@ class RealtimeMotionBuffer:
             body_quat_right,
             (t1 - t0).astype(np.float32, copy=False)[:, None] / 1e9,
         )
+        body_ang_vel_available = [
+            self._body_ang_vel_w_frames[left_idx] is not None
+            and self._body_ang_vel_w_frames[right_idx] is not None
+            for left_idx, right_idx in zip(left, right, strict=True)
+        ]
+        if any(body_ang_vel_available):
+            body_ang_vel_left = np.stack(
+                [
+                    self._body_ang_vel_w_frames[idx]
+                    if self._body_ang_vel_w_frames[idx] is not None
+                    else np.zeros((self._num_bodies, 3), dtype=np.float32)
+                    for idx in left
+                ],
+                axis=0,
+            )
+            body_ang_vel_right = np.stack(
+                [
+                    self._body_ang_vel_w_frames[idx]
+                    if self._body_ang_vel_w_frames[idx] is not None
+                    else np.zeros((self._num_bodies, 3), dtype=np.float32)
+                    for idx in right
+                ],
+                axis=0,
+            )
+            mask = np.asarray(body_ang_vel_available, dtype=bool)
+            body_ang_vel_lerp = body_ang_vel_left + alpha_body * (
+                body_ang_vel_right - body_ang_vel_left
+            )
+            body_ang_vel_w_out[mask] = body_ang_vel_lerp[mask]
 
     def cleanup(self, cutoff_ns: int) -> None:
         with self._lock:
@@ -318,8 +464,11 @@ class RealtimeMotionBuffer:
             while len(self._timestamps_ns) > 1 and self._timestamps_ns[1] < cutoff_ns:
                 self._timestamps_ns.pop(0)
                 self._joint_pos_frames.pop(0)
+                self._joint_vel_frames.pop(0)
                 self._body_pos_w_frames.pop(0)
+                self._body_lin_vel_w_frames.pop(0)
                 self._body_quat_w_frames.pop(0)
+                self._body_ang_vel_w_frames.pop(0)
 
     def get_obs(self) -> MotionData:
         current_time_ns = time.time_ns()

--- a/sim2real/rl_policy/utils/state_processor.py
+++ b/sim2real/rl_policy/utils/state_processor.py
@@ -134,6 +134,7 @@ class StateProcessor:
                 motion_zmq_hwm=int(self.motion_config.get("motion_zmq_hwm", 1)),
                 dt_s=float(self.motion_config.get("motion_dt_s", 0.02)),
                 tolerance_s=float(self.motion_config.get("motion_tolerance_s", 0.04)),
+                reconnect_timeout_s=float(self.motion_config.get("motion_reconnect_reset_s", 0.5)),
             )
 
             self.motion_joint_names = list(self.motion_buffer.joint_names)
@@ -163,6 +164,11 @@ class StateProcessor:
             self.motion_data = self.motion_buffer.get_obs()
         elif self.motion_backend == "smpl_zmq":
             self.motion_data = self.motion_buffer.get_obs()
+
+    def consume_motion_stream_reconnected(self) -> bool:
+        if self.motion_backend != "zmq":
+            return False
+        return bool(self.motion_buffer.consume_stream_reconnected())
 
     def register_subscriber(self, object_name: str, port: Optional[int] = None):
         if object_name in self.mocap_subscribers:

--- a/sim2real/teleop/npz_pub.py
+++ b/sim2real/teleop/npz_pub.py
@@ -1,0 +1,364 @@
+#!/usr/bin/env python3
+"""
+Replay an any4hdmi/npz motion as a canonical ZMQ motion stream.
+
+This is intentionally compatible with tracking.py --motion-backend zmq and the
+normal stream published by pico_retarget_pub.py.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import json
+import threading
+import time
+
+import mujoco
+import numpy as np
+import tyro
+import zmq
+
+from sim2real.config.robots import get_robot_cfg
+from sim2real.config.robots.base import (
+    BODY_NAMES_KEY,
+    BODY_POS_W_KEY,
+    BODY_QUAT_W_KEY,
+    JOINT_NAMES_KEY,
+    JOINT_POS_KEY,
+    PUBLISH_T_NS_KEY,
+    SEQ_KEY,
+)
+from sim2real.rl_policy.utils.motion import MotionDataset, motion_dataset_first_motion
+from sim2real.utils.math import yaw_quat
+from sim2real.utils.profiling import ScopedTimer
+
+
+SEND_TIMER_NAME = "npz_pub.send_payload"
+SAMPLE_TIMER_NAME = "npz_pub.sample_motion"
+
+
+def _array_payload(array: np.ndarray) -> list:
+    return np.asarray(array, dtype=np.float32).tolist()
+
+
+class KeyboardControls:
+    def __init__(self) -> None:
+        self._pending_keys: list[str] = []
+        self._pressed: set[str] = set()
+        self._lock = threading.Lock()
+        self._thread = threading.Thread(target=self._listen, daemon=True)
+        self._thread.start()
+
+    def _listen(self) -> None:
+        def on_press(keycode: str) -> None:
+            with self._lock:
+                if keycode in self._pressed:
+                    return
+                self._pressed.add(keycode)
+                self._pending_keys.append(keycode)
+
+        def on_release(keycode: str) -> None:
+            with self._lock:
+                self._pressed.discard(keycode)
+
+        from sshkeyboard import listen_keyboard
+
+        listen_keyboard(on_press=on_press, on_release=on_release)
+
+    def pop_keys(self) -> list[str]:
+        with self._lock:
+            keys = list(self._pending_keys)
+            self._pending_keys.clear()
+        return keys
+
+    def close(self) -> None:
+        try:
+            from sshkeyboard import stop_listening
+
+            stop_listening()
+        except Exception:
+            pass
+
+
+class NpzMotionPublisher:
+    def __init__(self, args: "PublisherArgs") -> None:
+        self.args = args
+        self.robot_cfg = get_robot_cfg(args.robot)
+        self.publish_hz = float(args.publish_hz)
+        if self.publish_hz <= 0.0:
+            raise ValueError("publish_hz must be > 0")
+
+        self.period_s = 1.0 / self.publish_hz
+        dataset = MotionDataset.create_from_path(
+            args.motion_path,
+            self.robot_cfg,
+            target_fps=int(round(self.publish_hz)),
+            mjcf_path=args.mjcf_path,
+        )
+        self.motion_dataset = motion_dataset_first_motion(dataset)
+        self.motion_length = int(self.motion_dataset.num_steps)
+        if self.motion_length <= 0:
+            raise ValueError(f"Motion has no frames: {args.motion_path}")
+
+        self.motion_ids = np.array([0], dtype=np.int64)
+        self.frame = int(args.start_frame)
+        self.frame = min(max(self.frame, 0), self.motion_length - 1)
+        self.seq = 0
+        self.source = str(args.initial_source)
+        self.paused = True
+        self.motion_body_indices = self._resolve_motion_body_indices()
+        self.root_body_index = tuple(self.robot_cfg.body_names).index("pelvis")
+
+        self.model = mujoco.MjModel.from_xml_path(str(self.robot_cfg.resolve_mjcf_path()))
+        self.joint_qpos_indices = self._resolve_joint_qpos_indices()
+        self.body_ids = self._resolve_body_ids()
+        self.default_qpos = np.asarray(self.robot_cfg.default_qpos, dtype=np.float32).copy()
+        (
+            self.default_joint_pos,
+            self.default_body_pos_w,
+            self.default_body_quat_w,
+        ) = self._pose_arrays_from_qpos(self.default_qpos)
+        self.aligned_default_qpos = self.default_qpos.copy()
+        self.aligned_default_joint_pos = self.default_joint_pos.copy()
+        self.aligned_default_body_pos_w = self.default_body_pos_w.copy()
+        self.aligned_default_body_quat_w = self.default_body_quat_w.copy()
+        self.latest_root_pos_w = self.default_body_pos_w[self.root_body_index].copy()
+        self.latest_root_quat_w = self.default_body_quat_w[self.root_body_index].copy()
+
+        self.keyboard = KeyboardControls() if args.keyboard else None
+
+    def _resolve_motion_body_indices(self) -> list[int]:
+        motion_body_names = list(self.motion_dataset.body_names)
+        missing = [name for name in self.robot_cfg.body_names if name not in motion_body_names]
+        if missing:
+            raise ValueError(f"Motion dataset missing robot bodies: {missing}")
+        return [motion_body_names.index(name) for name in self.robot_cfg.body_names]
+
+    def _resolve_joint_qpos_indices(self) -> list[int]:
+        indices: list[int] = []
+        for joint_name in self.robot_cfg.joint_names:
+            joint_id = mujoco.mj_name2id(self.model, mujoco.mjtObj.mjOBJ_JOINT, joint_name)
+            if joint_id < 0:
+                raise ValueError(f"Failed to resolve joint name in MJCF: {joint_name}")
+            indices.append(int(self.model.jnt_qposadr[joint_id]))
+        return indices
+
+    def _resolve_body_ids(self) -> list[int]:
+        body_ids: list[int] = []
+        for body_name in self.robot_cfg.body_names:
+            body_id = mujoco.mj_name2id(self.model, mujoco.mjtObj.mjOBJ_BODY, body_name)
+            if body_id < 0:
+                raise ValueError(f"Failed to resolve body name in MJCF: {body_name}")
+            body_ids.append(int(body_id))
+        return body_ids
+
+    def _pose_arrays_from_qpos(self, qpos: np.ndarray) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+        data = mujoco.MjData(self.model)
+        data.qpos[:] = np.asarray(qpos, dtype=np.float32).reshape(-1)
+        mujoco.mj_forward(self.model, data)
+        joint_pos = np.asarray(data.qpos[self.joint_qpos_indices], dtype=np.float32)
+        body_pos_w = np.asarray(data.xpos[self.body_ids], dtype=np.float32)
+        body_quat_w = np.asarray(data.xquat[self.body_ids], dtype=np.float32)
+        return joint_pos, body_pos_w, body_quat_w
+
+    def process_controls(self) -> None:
+        if self.keyboard is None:
+            return
+        for key in self.keyboard.pop_keys():
+            if key == "x":
+                if self.source == "default":
+                    self.source = "motion"
+                    print("[npz-publish] source=motion, press space to play/pause")
+                else:
+                    self.source = "default"
+                    self.paused = True
+                    self._capture_aligned_default_pose()
+                    print("[npz-publish] source=default, motion paused")
+            elif key == "space":
+                if self.source != "motion":
+                    print("[npz-publish] source=default; press x before playing motion")
+                    continue
+                self.paused = not self.paused
+                print(f"[npz-publish] motion paused={self.paused}")
+
+    def _next_frame(self) -> int:
+        frame = self.frame
+        if self.paused:
+            return frame
+        if self.frame < self.motion_length - 1:
+            self.frame += 1
+        elif self.args.loop:
+            self.frame = 0
+        elif self.args.hold_last:
+            self.paused = True
+            print("[npz-publish] reached end of motion; holding last frame")
+        else:
+            raise StopIteration
+        return frame
+
+    def _base_payload(self, source: str) -> dict[str, object]:
+        return {
+            "source": source,
+            "motion_path": str(self.args.motion_path),
+            "paused": bool(self.paused or source == "default"),
+            PUBLISH_T_NS_KEY: int(time.time_ns()),
+            SEQ_KEY: int(self.seq),
+        }
+
+    def _capture_aligned_default_pose(self) -> None:
+        aligned_qpos = self.default_qpos.copy()
+        aligned_qpos[self.robot_cfg.root_pos_slice.start : self.robot_cfg.root_pos_slice.stop] = (
+            self.default_qpos[self.robot_cfg.root_pos_slice]
+        )
+        aligned_qpos[0:2] = np.asarray(self.latest_root_pos_w[:2], dtype=np.float32)
+        aligned_qpos[self.robot_cfg.root_quat_slice] = yaw_quat(
+            np.asarray(self.latest_root_quat_w, dtype=np.float32)
+        ).astype(np.float32, copy=False)
+        self.aligned_default_qpos = aligned_qpos
+        (
+            self.aligned_default_joint_pos,
+            self.aligned_default_body_pos_w,
+            self.aligned_default_body_quat_w,
+        ) = self._pose_arrays_from_qpos(self.aligned_default_qpos)
+
+    def _default_payload(self) -> dict[str, object]:
+        payload = self._base_payload("default")
+        payload.update(
+            {
+                "frame": -1,
+                JOINT_NAMES_KEY: list(self.robot_cfg.joint_names),
+                BODY_NAMES_KEY: list(self.robot_cfg.body_names),
+                JOINT_POS_KEY: _array_payload(self.aligned_default_joint_pos),
+                BODY_POS_W_KEY: _array_payload(self.aligned_default_body_pos_w),
+                BODY_QUAT_W_KEY: _array_payload(self.aligned_default_body_quat_w),
+                "qpos": _array_payload(self.aligned_default_qpos),
+            }
+        )
+        if self.args.pub_vel:
+            payload.update(
+                {
+                    "joint_vel": _array_payload(np.zeros_like(self.aligned_default_joint_pos)),
+                    "body_lin_vel_w": _array_payload(np.zeros_like(self.aligned_default_body_pos_w)),
+                    "body_ang_vel_w": _array_payload(
+                        np.zeros((len(self.robot_cfg.body_names), 3), dtype=np.float32)
+                    ),
+                }
+            )
+        self.seq += 1
+        return payload
+
+    def sample_payload(self) -> dict[str, object]:
+        with ScopedTimer(SAMPLE_TIMER_NAME):
+            self.process_controls()
+            if self.source == "default":
+                return self._default_payload()
+
+            frame = self._next_frame()
+            motion = self.motion_dataset.get_slice(
+                self.motion_ids,
+                np.array([frame], dtype=np.int64),
+                np.array([0], dtype=np.int64),
+            )
+
+            payload = self._base_payload("npz")
+            body_pos_w = motion.body_pos_w[0, 0, self.motion_body_indices]
+            body_quat_w = motion.body_quat_w[0, 0, self.motion_body_indices]
+            self.latest_root_pos_w = np.asarray(body_pos_w[self.root_body_index], dtype=np.float32).copy()
+            self.latest_root_quat_w = np.asarray(body_quat_w[self.root_body_index], dtype=np.float32).copy()
+            payload.update(
+                {
+                    "frame": int(frame),
+                    JOINT_NAMES_KEY: list(self.motion_dataset.joint_names),
+                    BODY_NAMES_KEY: list(self.robot_cfg.body_names),
+                    JOINT_POS_KEY: _array_payload(motion.joint_pos[0, 0]),
+                    BODY_POS_W_KEY: _array_payload(body_pos_w),
+                    BODY_QUAT_W_KEY: _array_payload(body_quat_w),
+                }
+            )
+            if self.args.pub_vel:
+                payload.update(
+                    {
+                        "joint_vel": _array_payload(motion.joint_vel[0, 0]),
+                        "body_lin_vel_w": _array_payload(
+                            motion.body_lin_vel_w[0, 0, self.motion_body_indices]
+                        ),
+                        "body_ang_vel_w": _array_payload(
+                            motion.body_ang_vel_w[0, 0, self.motion_body_indices]
+                        ),
+                    }
+                )
+            self.seq += 1
+            return payload
+
+    def close(self) -> None:
+        if self.keyboard is not None:
+            self.keyboard.close()
+
+
+@dataclass
+class PublisherArgs:
+    """Publish an npz motion as canonical motion JSON over ZMQ."""
+
+    motion_path: str
+    robot: str = "g1"
+    bind: str = "tcp://*:28701"
+    publish_hz: float = 50.0
+    hwm: int = 1
+    startup_sleep_s: float = 0.5
+    start_frame: int = 0
+    loop: bool = False
+    hold_last: bool = True
+    pub_vel: bool = False
+    mjcf_path: str | None = None
+    initial_source: str = "default"
+    keyboard: bool = True
+
+
+def run_publish(args: PublisherArgs) -> None:
+    worker = NpzMotionPublisher(args)
+
+    ctx = zmq.Context.instance()
+    sock = ctx.socket(zmq.PUB)
+    sock.setsockopt(zmq.LINGER, 0)
+    sock.setsockopt(zmq.SNDHWM, int(args.hwm))
+    sock.setsockopt(zmq.CONFLATE, 1)
+    sock.bind(args.bind)
+
+    print(
+        f"[npz-publish] bind={args.bind} publish_hz={args.publish_hz} "
+        f"motion_path={args.motion_path} frames={worker.motion_length} "
+        f"loop={args.loop} hold_last={args.hold_last} "
+        f"pub_vel={args.pub_vel} "
+        f"initial_source={args.initial_source}"
+    )
+    if args.keyboard:
+        print("[npz-publish] keys: x toggles default/motion, space plays/pauses motion")
+    if args.startup_sleep_s > 0:
+        time.sleep(float(args.startup_sleep_s))
+
+    try:
+        next_tick = time.perf_counter()
+        while True:
+            payload = worker.sample_payload()
+            with ScopedTimer(SEND_TIMER_NAME):
+                sock.send_string(
+                    json.dumps(payload, separators=(",", ":")),
+                    flags=zmq.NOBLOCK,
+                )
+            next_tick += worker.period_s
+            sleep_s = next_tick - time.perf_counter()
+            if sleep_s > 0.0:
+                time.sleep(sleep_s)
+            else:
+                next_tick = time.perf_counter()
+    except StopIteration:
+        print("[npz-publish] reached end of motion.")
+    except KeyboardInterrupt:
+        print("KeyboardInterrupt, exiting npz publisher.")
+    finally:
+        worker.close()
+        sock.close(0)
+
+
+if __name__ == "__main__":
+    run_publish(tyro.cli(PublisherArgs))


### PR DESCRIPTION
## Summary

这个 PR 主要增加了 ZMQ 链路下的 NPZ motion publisher，并补齐 tracking 侧对 velocity payload、motion stream reconnect 的处理。

## 1. 新增 NPZ Publisher

新增 `sim2real/teleop/npz_pub.py`，可以把本地 any4hdmi / npz motion 作为 canonical ZMQ motion stream 发布，供 `tracking.py --motion-backend zmq` 使用。

示例：

```bash
uv run --no-sync sim2real/teleop/npz_pub.py \
  --motion-path ../any4hdmi/output/lafan/motions/walk1_subject1.npz \
  --robot g1 \
  --publish-hz 50
```

如果希望 publisher 同时发送 motion cache 里的 velocity，可以加 `--pub-vel`：

```bash
uv run --no-sync sim2real/teleop/npz_pub.py \
  --motion-path ../any4hdmi/output/lafan/motions/walk1_subject1.npz \
  --robot g1 \
  --publish-hz 50 \
  --pub-vel
```

`--pub-vel` 会额外发布：

- `joint_vel`
- `body_lin_vel_w`
- `body_ang_vel_w`

默认不加 `--pub-vel` 时，payload 行为保持 pose-only 形式。

## 2. Tracking 支持 Velocity Payload

`RealtimeMotionBuffer` 现在可以接收可选 velocity 输入。

处理逻辑：

- 如果 payload 中包含完整 velocity 字段，并且采样时左右两帧都有 velocity，则直接对 payload velocity 做 lerp。
- 如果 payload 没有 velocity，或者采样左右任一帧缺 velocity，则回退到原来的 finite difference 逻辑。
- 因此 Pico / 旧 publisher 不需要改动，仍然可以正常工作。

## 3. ZMQ Motion Reconnect 后自动 Reset Obs

tracking 侧现在会检测 ZMQ motion stream 的断流恢复。

默认逻辑：

- 如果超过 `0.5s` 没收到 motion payload；
- 下一次重新收到 motion payload 时；
- tracking 会 reset observations。

这样可以在 kill / restart publisher，或者切换 motion source 后，重新计算 observation 内部的 heading/root alignment，避免旧 reference 和新 reference 之间出现 root quat 突变导致 policy obs 跳变。

参数：

```bash
uv run --no-sync sim2real/rl_policy/tracking.py \
  --robot g1 \
  --motion-backend zmq \
  --motion-reconnect-reset-s 0.5
```

设为 `0` 可以关闭这个 reconnect reset 行为：

```bash
uv run --no-sync sim2real/rl_policy/tracking.py \
  --robot g1 \
  --motion-backend zmq \
  --motion-reconnect-reset-s 0
```

## 4. Pyproject 增加 CPU / G1 GPU Dependency Groups

`pyproject.toml` 增加了两个 dependency group，用于区分本地 CPU backend 和 G1 上的 GPU backend。

- `cpu`：使用 `onnxruntime`
- `g1-gpu`：使用 `onnxruntime-gpu`，用于 G1 / Orin 上启用 GPU backend

在 G1 上可以使用：

```bash
uv sync --group g1-gpu
```

然后运行 tracking 时选择 GPU backend：

```bash
uv run sim2real/rl_policy/tracking.py \
  --robot g1 \
  --inference-backend onnx-gpu \
  --motion-backend zmq
```

这样 G1 上可以通过 `g1-gpu` dependency group 安装 GPU ONNX runtime，并用 `onnx-gpu` backend 跑 policy。

## Summary by Sourcery

Add a ZMQ NPZ motion publisher, extend the motion buffer and tracking to support optional velocity payloads and motion stream reconnect handling, and introduce separate CPU/G1 GPU dependency groups for ONNX runtime backends.

New Features:
- Introduce an NPZ-based ZMQ motion publisher for replaying recorded motions as canonical motion streams.
- Allow the realtime motion buffer to ingest optional joint and body velocity payloads alongside pose data.

Enhancements:
- Add motion stream reconnect detection and observation reset in tracking to handle publisher restarts or source switches gracefully.
- Extend motion buffer interpolation to lerp provided velocity payloads when available while retaining finite-difference fallback.
- Expose configurable motion reconnect reset timeout through tracking runtime arguments and policy motion config.
- Introduce CPU and G1 GPU dependency groups to separate onnxruntime and onnxruntime-gpu installations and update the onnxruntime-gpu wheel source path.