### PR TITLE
chore: fix uv env err & make doc more readable

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,19 +20,37 @@ layout and onboard dependency notes.
 ## Quick Start
 
 ```bash
-uv sync
+# Specify device for inference
+uv sync --group cpu     # Sim2sim
+uv sync --group g1      # G1 Robot
+uv sync --group g1-gpu  # G1 Robot using GPU
 ```
 
 Run offline motion tracking (sim2sim):
 
 ```bash
+# Use Mirror for Acceleration (China Mainland)
+export HF_ENDPOINT=https://hf-mirror.com
+# Terminal 1: Launch sim
 uv run sim2real/sim_env/base_sim.py --robot g1
+# Terminal 2: Launch policy
 uv run sim2real/rl_policy/tracking.py --robot g1 \
   --policy_config checkpoints/mimic-lite/32x8192-huge/policy.yaml \
   --motion_path hf://elijahgalahad/any4hdmi-g1-lafan/motions/walk1_subject1.npz
 ```
 
+### Keyboard Controls
+
 After both processes are up, press `]` in the policy terminal to start. Open the mjviser URL printed by `base_sim.py`, then use the Elastic Band controls in the viewer UI to disable or tune the virtual gantry.
+
+Keys are read in the policy (`tracking.py`) terminal:
+
+| Key | Function |
+|-----|----------|
+| `i` | Init mode: interpolate joints from the current pose to the default pose (~10 s ramp) |
+| `o` | Zero mode: hold the current joint positions |
+| `]` | Policy mode: reset and start RL policy inference |
+| `Space` | Pause / resume reference motion playback (starts paused; `npz` motion backend only) |
 
 ## Migrating to sim2real
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -19,19 +19,37 @@ Full documentation: [https://egalahad.github.io/sim2real/](https://egalahad.gith
 ## 快速开始
 
 ```bash
-uv sync
+# 根据推理设备选择依赖组
+uv sync --group cpu     # Sim2sim
+uv sync --group g1      # G1 机器人
+uv sync --group g1-gpu  # G1 机器人（GPU 推理）
 ```
 
 运行离线动作跟踪（sim2sim）：
 
 ```bash
+# 使用镜像加速（中国大陆）
+export HF_ENDPOINT=https://hf-mirror.com
+# 终端 1：启动仿真
 uv run sim2real/sim_env/base_sim.py --robot g1
-uv run sim2real/rl_policy/tracking.py \
-  --robot g1 \
-  --policy_config checkpoints/mimic-lite/32x8192-huge/policy.yaml
+# 终端 2：启动 policy
+uv run sim2real/rl_policy/tracking.py --robot g1 \
+  --policy_config checkpoints/mimic-lite/32x8192-huge/policy.yaml \
+  --motion_path hf://elijahgalahad/any4hdmi-g1-lafan/motions/walk1_subject1.npz
 ```
 
+### 键盘控制
+
 两个进程都启动后，在 policy 终端按 `]` 开始跟踪，然后打开 `base_sim.py` 打印出来的 mjviser URL。虚拟 gantry / elastic band 的开关和长度在 viewer UI 里调。
+
+按键在 policy（`tracking.py`）终端里读取：
+
+| 按键 | 功能 |
+|------|------|
+| `i` | Init 模式：关节从当前姿态插值到默认姿态（约 10 s 缓动） |
+| `o` | Zero 模式：保持当前关节位置 |
+| `]` | Policy 模式：reset 并开始 RL policy 推理 |
+| `Space` | 暂停 / 恢复参考动作播放（启动时为暂停状态；仅 `npz` motion backend 有效） |
 
 ## Migrating to sim2real
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ include = ["sim2real*"]
 
 [tool.uv]
 package = true
-find-links = ["third_party/wheels"]
+# find-links = ["third_party/wheels"]
 
 [[tool.uv.index]]
 name = "nvidia-pypi"

--- a/uv.lock
+++ b/uv.lock
@@ -1161,13 +1161,14 @@ dependencies = [
 sdist = { url = "https://pypi.tuna.tsinghua.edu.cn/packages/24/d6/7126f9e7de139632134d59b5d1972e93c610ee2cb13829e8f4f48f6613cb/tyro-1.0.13.tar.gz", hash = "sha256:731a90c9836b77fffe7c3fa0477ef2d3b6fa91252ddc0bb4d32dadd4fcc143d4", size = 489479, upload-time = "2026-04-14T18:21:52.888Z" }
 wheels = [
     { url = "https://pypi.tuna.tsinghua.edu.cn/packages/93/4f/c43a0a8f0c66fd40a1d6cc47332a5a1d1043e9b331f7070ea701b91a7598/tyro-1.0.13-py3-none-any.whl", hash = "sha256:a0bdb8462c551dd84fc00a76916ce4d37e879c84eefaf34e2165312407cc6c09", size = 185221, upload-time = "2026-04-14T18:21:54.328Z" },
+]
+
 [[package]]
 name = "unitree-interface"
 version = "0.1.0"
 source = { registry = "third_party/wheels" }
 wheels = [
     { path = "unitree_interface-0.1.0-cp310-cp310-linux_aarch64.whl" },
-]
 ]
 
 [[package]]


### PR DESCRIPTION
- fix: Failed to parse `uv.lock', TOML parse error at line 1165
- comment out find-links = ["third_party/wheels"] (for git clone empty dir will not be created, leading to uv err)
- update README

Question: Is the third_party/wheel needed when sim2real deploying? If so may be the readme file should not be removed for directory reservation. (3b5ce0a40ed6c54ea9aec33b7d513028a97605e2)

## Summary by Sourcery

Clarify environment setup for running sim2real demos and address a uv dependency resolution issue.

Bug Fixes:
- Regenerate or fix the uv lockfile to resolve a TOML parse error.

Build:
- Comment out the custom `find-links` wheel directory in uv configuration to avoid errors when the directory is missing.

Documentation:
- Document uv sync usage per hardware group and add keyboard control reference for sim2sim tracking in both English and Chinese READMEs.